### PR TITLE
Template literals require backticks

### DIFF
--- a/src/i18n/I18n.js
+++ b/src/i18n/I18n.js
@@ -30,7 +30,7 @@ class I18n {
             this.strings.add(strings.trim());
         } else {
             Array.from(strings)
-                .filter(string => string && ('${string}').trim().length > 0)
+                .filter(string => string && (`${string}`).trim().length > 0)
                 .forEach(string => this.strings.add(string));
         }
     }


### PR DESCRIPTION
`('${string}').trim().length > 0` will always be true.