### PR TITLE
Modify the handling of attributeValues

### DIFF
--- a/src/model/Model.js
+++ b/src/model/Model.js
@@ -104,10 +104,19 @@ class Model {
                                 .filter(av => av.attribute.name === attributeName)
                                 .reduce((current, av) => av, undefined);
 
+                            // Don't do anything if the value stayed the same
+                            if (attributeValue && attributeValue.value === value) {
+                                return;
+                            }
+
                             if (attributeValue) {
-                                // Don't do anything if the value stayed the same
-                                if (attributeValue.value === value) {
-                                    return;
+                                // Remove the attributeValue from the array of attributeValues on the object
+                                // This is done because the server can not handle them properly when empty strings
+                                // as values are sent. It will properly remove the attributeValue
+                                // on the server side when they are not being send to the server at all.
+                                if (value === undefined || value === null || value === '') {
+                                    this.attributeValues = this.attributeValues
+                                        .filter(av => av !== attributeValue);
                                 }
 
                                 attributeValue.value = value;

--- a/test/unit/model/Model_spec.js
+++ b/test/unit/model/Model_spec.js
@@ -233,6 +233,66 @@ describe('Model', () => {
             expect(dataElementModel.attributeValues.length).to.equal(2);
         });
 
+        it('should remove the attributeValue from the attributeValue array when the value is cleared out', () => {
+            dataElementModel.dataValues.attributeValues = [{
+                value: 'Mark',
+                attribute: { id: 'FpoWdhxCMwH', name: 'name' }
+            }];
+
+            dataElementModel.attributes.name = '';
+
+            expect(dataElementModel.attributes.name).to.equal(undefined);
+            expect(dataElementModel.attributeValues.length).to.equal(0);
+        });
+
+        it('should not remove the attributeValue when the attribute is set to false', () => {
+            dataElementModel.dataValues.attributeValues = [{
+                value: 'Mark',
+                attribute: { id: 'FpoWdhxCMwH', name: 'name' }
+            }];
+
+            dataElementModel.attributes.name = false;
+
+            expect(dataElementModel.attributes.name).to.equal(false);
+            expect(dataElementModel.attributeValues.length).to.equal(1);
+        });
+
+        it('should not remove the attributeValue when the attribute is set 0', () => {
+            dataElementModel.dataValues.attributeValues = [{
+                value: 'Mark',
+                attribute: { id: 'FpoWdhxCMwH', name: 'name' }
+            }];
+
+            dataElementModel.attributes.name = 0;
+
+            expect(dataElementModel.attributes.name).to.equal(0);
+            expect(dataElementModel.attributeValues.length).to.equal(1);
+        });
+
+        it('should remove the attributeValue when the attribute is set to undefined', () => {
+            dataElementModel.dataValues.attributeValues = [{
+                value: 'Mark',
+                attribute: { id: 'FpoWdhxCMwH', name: 'name' }
+            }];
+
+            dataElementModel.attributes.name = undefined;
+
+            expect(dataElementModel.attributes.name).to.equal(undefined);
+            expect(dataElementModel.attributeValues.length).to.equal(0);
+        });
+
+        it('should remove the attributeValue when the attribute is set to null', () => {
+            dataElementModel.dataValues.attributeValues = [{
+                value: 'Mark',
+                attribute: { id: 'FpoWdhxCMwH', name: 'name' }
+            }];
+
+            dataElementModel.attributes.name = null;
+
+            expect(dataElementModel.attributes.name).to.equal(undefined);
+            expect(dataElementModel.attributeValues.length).to.equal(0);
+        });
+
         it('should not show up in the list of model keys', () => {
             const modelKeys = Object.keys(dataElementModel);
 


### PR DESCRIPTION
An attributeValue will be removed from the attributeValues array
when the value is set to ''(empty string), undefined or null.

We do allow false or 0 as they are allowed and will be changed to
"false" and "0" on the server side.