### PR TITLE
Reset the global.FormData on each test run.

### DIFF
--- a/test/setup/node.js
+++ b/test/setup/node.js
@@ -7,10 +7,9 @@ global.chai.use(require('chai-as-promised'));
 
 global.expect = global.chai.expect;
 
-// fetch and FormData for node
+// fetch for node
 global.fetch = require('node-fetch');
 global.Headers = fetch.Headers;
-global.FormData = require('form-data');
 
 process.on('unhandledRejection', (reason, p) => {
     const e = new Error();

--- a/test/unit/api/api_spec.js
+++ b/test/unit/api/api_spec.js
@@ -1,3 +1,4 @@
+import nodeFormData from 'form-data';
 import '../../setup/setup';
 import System from '../../../src/system/System';
 
@@ -438,6 +439,9 @@ describe('Api', () => {
         });
 
         it('should set remove the Content-Type header for form data', (done) => {
+            // Set the global FormData
+            global.FormData = nodeFormData;
+
             const data = new FormData();
             data.append('field_1', 'value_1');
             data.append('field_2', 'value_2');
@@ -446,6 +450,9 @@ describe('Api', () => {
                 .then(() => {
                     expect(fetchMock.args[0][1].headers.constructor.name).to.equal('Headers');
                     expect(fetchMock.args[0][1].headers.get('Content-Type')).to.be.null;
+
+                    // Unset the global FormData
+                    global.FormData = undefined;
                     done();
                 })
                 .catch(done);


### PR DESCRIPTION
The global.FormData would be set to undefined when the tests are run
in watch mode. This would therefore make the FormData test fail on
each re-run after the initial run.