### PR TITLE
Use static DataStore.getDataStore method for init

### DIFF
--- a/src/d2.js
+++ b/src/d2.js
@@ -8,7 +8,7 @@ import I18n from './i18n/I18n';
 import Config from './config';
 import CurrentUser from './current-user/CurrentUser';
 import { fieldsForSchemas } from './model/config';
-import { dataStore } from './datastore/DataStore';
+import DataStore from './datastore/DataStore';
 
 let firstRun = true;
 let deferredD2Init = Deferred.create();
@@ -122,7 +122,7 @@ export function init(initConfig, ApiClass = Api, logger = Logger.getLogger()) {
         Api: ApiClass,
         system: System.getSystem(),
         i18n: I18n.getI18n(),
-        dataStore,
+        dataStore: DataStore.getDataStore(),
     };
 
     // Process the config in a the config class to keep all config calls together.

--- a/src/datastore/DataStore.js
+++ b/src/datastore/DataStore.js
@@ -90,9 +90,23 @@ class DataStore {
         return this.api.delete([this.endPoint, namespace].join('/'));
     }
 
-}
+    /**
+     * @method getDataStore
+     * @static
+     *
+     * @returns {DataStore} Object with the dataStore interaction properties
+     *
+     * @description
+     * Get a new instance of the dataStore object. This will function as a singleton, when a DataStore object has been created
+     * when requesting getDataStore again the original version will be returned.
+     */
+    static getDataStore() {
+        if (!DataStore.getDataStore.dataStore) {
+            DataStore.getDataStore.dataStore = new DataStore();
+        }
 
-export const dataStore = (() =>
-    new DataStore())();
+        return DataStore.getDataStore.dataStore;
+    }
+}
 
 export default DataStore;

--- a/test/unit/d2_spec.js
+++ b/test/unit/d2_spec.js
@@ -1,5 +1,6 @@
 import '../setup/setup.js'; // Import for global beforeEach / afterEach
 import fixtures from '../fixtures/fixtures';
+import DataStore from '../../src/datastore/DataStore';
 
 // TODO: The Config class should probably be mocked
 describe('D2', () => {
@@ -428,6 +429,15 @@ describe('D2', () => {
                     expect(apiMock.get).to.have.been.calledWith('schemas/user', {
                         fields: 'apiEndpoint,name,displayName,authorities,singular,plural,shareable,metadata,klass,identifiableObject,translatable,properties[href,writable,collection,collectionName,name,propertyType,persisted,required,min,max,ordered,unique,constants,owner,itemPropertyType,translationKey]',
                     });
+                });
+        });
+    });
+
+    describe('DataStore', () => {
+        it('should have a dataStore object on the instance', () => {
+            return d2.init(undefined, apiMock)
+                .then(d2Instance => {
+                    expect(d2Instance.dataStore).to.be.instanceof(DataStore);
                 });
         });
     });

--- a/test/unit/datastore/DataStore_spec.js
+++ b/test/unit/datastore/DataStore_spec.js
@@ -114,4 +114,14 @@ describe('DataStore', () => {
             }).catch(e => done(e));
         });
     });
+
+    describe('getDataStore', () => {
+        it('should return an instance of DataStore', () => {
+            expect(DataStore.getDataStore()).to.be.instanceof(DataStore);
+        });
+
+        it('should return the same object when called twice', () => {
+            expect(DataStore.getDataStore()).to.equal(DataStore.getDataStore());
+        });
+    });
 });


### PR DESCRIPTION
Creating the singleton when evaluating the module would cause
problems. when trying to fake/mock the api for cases where fetch
might not be available or is mocked in the beforeEach of a test.
This also bring the retrieval of the dataStore in line with how it
works for e.g. SystemSettings.