### PR TITLE
Remove deprecated `dataType` and `contentType` request options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,19 @@
 ## 28.0.0
 ###### _September 19th 2017_
 
-** Breaking changes: **
+**Breaking changes:**
 
-- `d2.system.loadAppStore` has changed in order to support the new
-  [central app store](https://play.dhis2.org/appstore).
-- Support for `dataType` and `contentType` options have been removed.
-  These were added for compatibility with jQuery, and have been
-  deprecated since version 2.25.
+- `d2.system.loadAppStore` has changed in order to support the new [central app store](https://play.dhis2.org/appstore).
+- Support for `dataType` and `contentType` options on API requests have been removed. These were added for
+  compatibility with jQuery, and have been deprecated since version 2.25. To migrate, manipulate the request headers
+  directly instead:
+  - `dataType` corresponds to the `Accept` header:
+    - Before: `api.get(url, { dataType: 'text' })`
+    - Now: `api.get(url, { headers: { 'Accept': 'text/plain' }})`
+  - `contentType` corresponds to the `Content-Type` header:
+    - Before: `api.post(url, data, { contentType: 'text' })`
+    - Now: `api.post(url, data, { headers: { 'Content-Type': 'text/plain' }})`
+
 
 ## 27.0.0
 ###### _February 20th 2016_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 
 - `d2.system.loadAppStore` has changed in order to support the new
   [central app store](https://play.dhis2.org/appstore).
-
+- Support for `dataType` and `contentType` options have been removed.
+  These were added for compatibility with jQuery, and have been
+  deprecated since version 2.25.
 
 ## 27.0.0
 ###### _February 20th 2016_

--- a/package.json
+++ b/package.json
@@ -67,5 +67,11 @@
   "nyc": {
     "sourceMap": false,
     "instrument": false
+  },
+  "jest": {
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/__fixtures__/"
+    ]
   }
 }

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -52,12 +52,12 @@ describe('Api', () => {
         let wasFetch;
 
         beforeEach(() => {
-            wasFetch = global.fetch;
-            delete global.fetch;
+            wasFetch = (window || global).fetch;
+            delete (window || global).fetch;
         });
 
         afterEach(() => {
-            global.fetch = wasFetch;
+            (window || global).fetch = wasFetch;
         });
 
         it('should throw', () => {

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -48,6 +48,23 @@ describe('Api', () => {
         expect(() => Api(fetchMock)).toThrowError('Cannot call a class as a function'); // eslint-disable-line
     });
 
+    describe('when fetch is not supported', () => {
+        let wasFetch;
+
+        beforeEach(() => {
+            wasFetch = global.fetch;
+            delete global.fetch;
+        });
+
+        afterEach(() => {
+            global.fetch = wasFetch;
+        });
+
+        it('should throw', () => {
+            expect(() => new Api()).toThrowError();
+        });
+    });
+
     describe('getApi', () => {
         it('should have a method to get an instance of Api', () => {
             expect(Api.getApi).toBeInstanceOf(Function);
@@ -148,7 +165,14 @@ describe('Api', () => {
         });
 
         it('should report 404 errors', (done) => {
-            const errorText = '{"httpStatus":"Not Found","httpStatusCode":404,"status":"ERROR","message":"DataElement with id 404 could not be found."}';
+            const errorText = [
+                '{',
+                '"httpStatus":"Not Found",',
+                '"httpStatusCode":404,',
+                '"status":"ERROR",',
+                '"message":"DataElement with id 404 could not be found."',
+                '}',
+            ].join('');
             fetchMock.mockReturnValueOnce(Promise.resolve({
                 ok: false,
                 status: 404,
@@ -166,8 +190,23 @@ describe('Api', () => {
         });
 
         it('should report 500 errors', (done) => {
-            const errorText = '{"httpStatus":"Internal Server Error","httpStatusCode":500,"status":"ERROR","message":"object references an unsaved transient instance - save the transient instance before flushing: org.hisp.dhis.dataelement.CategoryOptionGroupSet"}';
-            const data = '{"name":"District Funding Agency","orgUnitLevel":2,"categoryOptionGroupSet":{"id":"SooXFOUnciJ"}}';
+            const errorText = [
+                '{',
+                '"httpStatus":"Internal Server Error",',
+                '"httpStatusCode":500,',
+                '"status":"ERROR",',
+                '"message":',
+                '"object references an unsaved transient instance - save the transient instance before flushing: ',
+                'org.hisp.dhis.dataelement.CategoryOptionGroupSet"',
+                '}',
+            ].join('');
+            const data = [
+                '{',
+                '"name":"District Funding Agency",',
+                '"orgUnitLevel":2,',
+                '"categoryOptionGroupSet":{"id":"SooXFOUnciJ"}',
+                '}',
+            ].join('');
             fetchMock.mockReturnValueOnce(Promise.resolve({
                 ok: false,
                 status: 500,
@@ -184,13 +223,21 @@ describe('Api', () => {
                 .catch(done);
         });
 
-        it('should properly encode URIs', () => api.get('some/endpoint?a=b&c=d|e', { f: 'g|h[i,j],k[l|m],n{o~p`q`$r@s!t}', u: '-._~:/?#[]@!$&()*+,;===,~$!@*()_-=+/;:' })
-            .then(() => {
-                expect(fetchMock).toHaveBeenCalledWith(
-                    '/api/some/endpoint?a=b&c=d|e&f=g%7Ch%5Bi%2Cj%5D%2Ck%5Bl%7Cm%5D%2Cn%7Bo~p%60q%60%24r%40s!t%7D&u=-._~%3A%2F%3F%23%5B%5D%40!%24%26()*%2B%2C%3B%3D%3D%3D%2C~%24!%40*()_-%3D%2B%2F%3B%3A',
-                    baseFetchOptions,
-                );
-            }));
+        it('should properly encode URIs', () => api
+            .get('some/endpoint?a=b&c=d|e', {
+                f: 'g|h[i,j],k[l|m],n{o~p`q`$r@s!t}',
+                u: '-._~:/?#[]@!$&()*+,;===,~$!@*()_-=+/;:',
+            })
+            .then(() => expect(fetchMock).toHaveBeenCalledWith([
+                '/api/some/endpoint?',
+                'a=b&',
+                'c=d|e&',
+                'f=g%7Ch%5Bi%2Cj%5D%2Ck%5Bl%7Cm%5D%2Cn%7Bo~p%60q%60%24r%40s!t%7D&',
+                'u=-._~%3A%2F%3F%23%5B%5D%40!%24%26()*%2B%2C%3B%3D%3D%3D%2C~%24!%40*()_-%3D%2B%2F%3B%3A',
+            ].join(''),
+            baseFetchOptions,
+            )),
+        );
 
         it('should not break URIs when encoding', () => api.get('test?a=b=c&df,gh')
             .then(() => {

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -387,27 +387,6 @@ describe('Api', () => {
             );
         });
 
-        it('should post the number zero with the deprecated dataType option', () => {
-            api.post('systemSettings/numberZero', 0, { dataType: 'text' });
-
-            expect(fetchMock).toBeCalledWith(
-                '/api/systemSettings/numberZero',
-                {
-                    body: '0',
-                    cache: 'default',
-                    credentials: 'include',
-                    headers: {
-                        map: {
-                            accept: 'text/plain',
-                            'content-type': 'application/json',
-                        },
-                    },
-                    method: 'POST',
-                    mode: 'cors',
-                },
-            );
-        });
-
         it('should send plain text boolean true values as "true"', () => {
             api.post('systemSettings/keyTrue', true);
 

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -53,11 +53,13 @@ describe('Api', () => {
 
         beforeEach(() => {
             wasFetch = (window || global).fetch;
-            delete (window || global).fetch;
+            if (window !== undefined) window.fetch = undefined;
+            if (global !== undefined) global.fetch = undefined;
         });
 
         afterEach(() => {
-            (window || global).fetch = wasFetch;
+            if (window !== undefined) window.fetch = wasFetch;
+            if (global !== undefined) global.fetch = wasFetch;
         });
 
         it('should throw', () => {

--- a/src/datastore/__tests__/DataStore.spec.js
+++ b/src/datastore/__tests__/DataStore.spec.js
@@ -20,13 +20,13 @@ describe('DataStore', () => {
     });
 
     describe('get()', () => {
-        beforeEach(() => {
+        it('should return an instance of datastorenamespace', () => {
             apiMock.get.mockReturnValueOnce(Promise.resolve(keys));
-        });
 
-        it('should return an instance of datastorenamespace', () => dataStore.get('DHIS').then((namespace) => {
-            expect(namespace).toBeInstanceOf(DataStoreNamespace);
-        }));
+            dataStore.get('DHIS').then((namespace) => {
+                expect(namespace).toBeInstanceOf(DataStoreNamespace);
+            });
+        });
 
         it('should return a datastorenamespace with keys if it exists', () => {
             apiMock.get.mockReturnValueOnce(Promise.resolve(keys));
@@ -65,6 +65,25 @@ describe('DataStore', () => {
                 .catch((e) => {
                     expect(e).toEqual(error);
                 });
+        });
+
+        describe('for an invalid namespace', () => {
+            beforeEach(() => {
+                apiMock.get.mockReturnValueOnce(Promise.reject([
+                    '{',
+                    '"httpStatus":"Not Found",',
+                    '"httpStatusCode":404,',
+                    '"status":"ERROR",',
+                    '"message":"The namespace \'not-my-namespace\' was not found."',
+                    '}',
+                ].join('')));
+            });
+
+            it('should throw an error', (done) => {
+                return dataStore.get('some-invalid-namespace-that-no-exis-does').then(() => {
+                    throw new Error('this should have failed');
+                }).catch(() => done());
+            });
         });
     });
 


### PR DESCRIPTION
API requests no longer support `dataType` and `contentType` options, which were only kept for backward compatibility with jQuery. See CHANGELOG.md for migration steps.