### PR TITLE
Fix parsing error in .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,7 @@ engines:
     - __tests__
     - __mocks__
     - __fixtures__
-    - **.spec.js
+    - "**.spec.js"
   eslint:
     enabled: true
     exclude_paths:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,11 +2,13 @@ engines:
   duplication:
     enabled: true
     exclude_paths:
-    - __tests__
-    - __mocks__
-    - __fixtures__
+    - "__tests__/**"
+    - "__mocks__/**"
+    - "__fixtures__/**"
     - "**.spec.js"
   eslint:
     enabled: true
     exclude_paths:
-    - __fixtures__
+    - "__fixtures__/**"
+exclude_paths:
+- "**.spec.js"


### PR DESCRIPTION
Text beginning with ** requires quotes (line 8) in order to parse. So, for consistency, added quotes around all values.

Also added exclude_paths at the root level to ensure that test files are never evaluated.