### PR TITLE
Use current year instead of hard coded '2017' to fix period tests

### DIFF
--- a/src/period/generators/__tests__/bi-monthly_spec.js
+++ b/src/period/generators/__tests__/bi-monthly_spec.js
@@ -49,7 +49,7 @@ describe('Bi-monthly period', () => {
         });
 
         it('should generate the same periods when called without as when called with the current year', () => {
-            expect(generateBiMonthlyPeriodsForYear()).toEqual(generateBiMonthlyPeriodsForYear(2017));
+            expect(generateBiMonthlyPeriodsForYear()).toEqual(generateBiMonthlyPeriodsForYear(new Date().getFullYear()));
         });
     });
 });

--- a/src/period/generators/__tests__/financial-april_spec.js
+++ b/src/period/generators/__tests__/financial-april_spec.js
@@ -133,7 +133,7 @@ describe('Financial April period', () => {
         });
 
         it('should generate use the current year when no year has been given', () => {
-            expect(generateFinancialAprilPeriodsUpToYear()).toEqual(generateFinancialAprilPeriodsUpToYear(2017));
+            expect(generateFinancialAprilPeriodsUpToYear()).toEqual(generateFinancialAprilPeriodsUpToYear(new Date().getFullYear()));
         });
     });
 });

--- a/src/period/generators/__tests__/financial-july_spec.js
+++ b/src/period/generators/__tests__/financial-july_spec.js
@@ -133,7 +133,7 @@ describe('Financial July period', () => {
         });
 
         it('should generate use the current year when no year has been given', () => {
-            expect(generateFinancialJulyPeriodsUpToYear()).toEqual(generateFinancialJulyPeriodsUpToYear(2017));
+            expect(generateFinancialJulyPeriodsUpToYear()).toEqual(generateFinancialJulyPeriodsUpToYear(new Date().getFullYear()));
         });
     });
 });

--- a/src/period/generators/__tests__/financial-october_spec.js
+++ b/src/period/generators/__tests__/financial-october_spec.js
@@ -133,7 +133,7 @@ describe('Financial October period', () => {
         });
 
         it('should generate use the current year when no year has been given', () => {
-            expect(generateFinancialOctoberPeriodsUpToYear()).toEqual(generateFinancialOctoberPeriodsUpToYear(2017));
+            expect(generateFinancialOctoberPeriodsUpToYear()).toEqual(generateFinancialOctoberPeriodsUpToYear(new Date().getFullYear()));
         });
     });
 });

--- a/src/period/generators/__tests__/monthly_spec.js
+++ b/src/period/generators/__tests__/monthly_spec.js
@@ -26,7 +26,7 @@ describe('Monthly period', () => {
         });
 
         it('should generate the same periods when called without as when called with the current year', () => {
-            expect(generateMonthlyPeriodsForYear()).toEqual(generateMonthlyPeriodsForYear(2017));
+            expect(generateMonthlyPeriodsForYear()).toEqual(generateMonthlyPeriodsForYear(new Date().getFullYear()));
         });
     });
 });

--- a/src/period/generators/__tests__/quarterly_spec.js
+++ b/src/period/generators/__tests__/quarterly_spec.js
@@ -41,7 +41,7 @@ describe('Quarterly period', () => {
         });
 
         it('should generate the same periods when called without as when called with the current year', () => {
-            expect(generateQuarterlyPeriodsForYear()).toEqual(generateQuarterlyPeriodsForYear(2017));
+            expect(generateQuarterlyPeriodsForYear()).toEqual(generateQuarterlyPeriodsForYear(new Date().getFullYear()));
         });
     });
 });

--- a/src/period/generators/__tests__/six-monthly-april_spec.js
+++ b/src/period/generators/__tests__/six-monthly-april_spec.js
@@ -49,7 +49,7 @@ describe('Six-monthly-april period', () => {
         });
 
         it('should use the current year when no year has been given', () => {
-            expect(generateSixMonthlyAprilPeriodsForYear()).toEqual(generateSixMonthlyAprilPeriodsForYear(2017));
+            expect(generateSixMonthlyAprilPeriodsForYear()).toEqual(generateSixMonthlyAprilPeriodsForYear(new Date().getFullYear()));
         });
     });
 });

--- a/src/period/generators/__tests__/six-monthly_spec.js
+++ b/src/period/generators/__tests__/six-monthly_spec.js
@@ -31,7 +31,7 @@ describe('Six-monthly period', () => {
         });
 
         it('should generate the same periods when called without as when called with the current year', () => {
-            expect(generateSixMonthlyPeriodsForYear()).toEqual(generateSixMonthlyPeriodsForYear(2017));
+            expect(generateSixMonthlyPeriodsForYear()).toEqual(generateSixMonthlyPeriodsForYear(new Date().getFullYear()));
         });
     });
 });

--- a/src/period/generators/__tests__/weekly_spec.js
+++ b/src/period/generators/__tests__/weekly_spec.js
@@ -38,7 +38,7 @@ describe('Weekly period', () => {
         });
 
         it('should generate the correct result for each period', () => {
-            const periods = generateWeeklyPeriodsForYear();
+            const periods = generateWeeklyPeriodsForYear(2017);
 
             expect(periods[0]).toEqual({
                 startDate: '2017-01-02',
@@ -112,7 +112,7 @@ describe('Weekly period', () => {
         });
 
         it('should generate the same periods when called without as when called with the current year', () => {
-            expect(generateWeeklyPeriodsForYear()).toEqual(generateWeeklyPeriodsForYear(2017));
+            expect(generateWeeklyPeriodsForYear()).toEqual(generateWeeklyPeriodsForYear(new Date().getFullYear()));
         });
 
         it('should have 71 years in 400-year cycle with iso week 53', () => {

--- a/src/period/generators/__tests__/yearly_spec.js
+++ b/src/period/generators/__tests__/yearly_spec.js
@@ -133,7 +133,7 @@ describe('Yearly period', () => {
         });
 
         it('should use the current year when no year has been given', () => {
-            expect(generateYearlyPeriodsUpToYear()).toEqual(generateYearlyPeriodsUpToYear(2017));
+            expect(generateYearlyPeriodsUpToYear()).toEqual(generateYearlyPeriodsUpToYear(new Date().getFullYear()));
         });
     });
 });


### PR DESCRIPTION
While downloading the lib & running test, found a bunch of them broken due to hard coding 2017 as "current year" (which is not the case anymore).

Replaced them by calls to new Date().getFullYear() to get them running for the years to come.

Happy new year!