### PR TITLE
Use `/api` by default for 2.29

### DIFF
--- a/src/__tests__/Config_spec.js
+++ b/src/__tests__/Config_spec.js
@@ -35,7 +35,7 @@ describe('Config', () => {
         it('should call setBaseUrl with the default api location', () => {
             Config.processConfigForD2({}, mockD2);
 
-            expect(mockApi.setBaseUrl).toBeCalledWith('/api/25');
+            expect(mockApi.setBaseUrl).toBeCalledWith('/api/26');
         });
     });
 });

--- a/src/__tests__/Config_spec.js
+++ b/src/__tests__/Config_spec.js
@@ -35,7 +35,7 @@ describe('Config', () => {
         it('should call setBaseUrl with the default api location', () => {
             Config.processConfigForD2({}, mockD2);
 
-            expect(mockApi.setBaseUrl).toBeCalledWith('/api/26');
+            expect(mockApi.setBaseUrl).toBeCalledWith('/api');
         });
     });
 });

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 import defaultConfig from './defaultConfig';
 import { isType, isString } from './lib/check';
 
-const DEFAULT_API_VERSION = 25;
+const DEFAULT_API_VERSION = 26;
 
 export default class Config {
     static create(...args) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,6 @@
 import defaultConfig from './defaultConfig';
 import { isType, isString } from './lib/check';
 
-const DEFAULT_API_VERSION = 26;
-
 export default class Config {
     static create(...args) {
         const configObjects = args
@@ -23,7 +21,8 @@ export default class Config {
         if (isString(config.baseUrl)) {
             api.setBaseUrl(config.baseUrl);
         } else {
-            api.setBaseUrl(`/api/${DEFAULT_API_VERSION}`);
+            // default to the current version of the `/api`
+            api.setBaseUrl('/api');
         }
 
         if (config.i18n && config.i18n.sources) {


### PR DESCRIPTION
… 2.29