### PR TITLE
Add 'favorites' as a non-embedded collection property for all model types

### DIFF
--- a/src/model/helpers/__tests__/json.spec.js
+++ b/src/model/helpers/__tests__/json.spec.js
@@ -107,4 +107,30 @@ describe('getJSONForProperties', () => {
             });
         });
     });
+
+    describe('property types', () => {
+        it('should handle non-embedded collection properties', () => {
+            const favoritesPropName = 'favorites';
+            const favoritesValue = ['userId1', 'userId2'];
+            const model = {
+                modelDefinition: {
+                    modelValidations: {
+                        favorites: {},
+                    },
+                },
+                dataValues: {
+                    [favoritesPropName]: favoritesValue,
+                },
+                getCollectionChildrenPropertyNames: () => [favoritesPropName],
+                getReferenceProperties: () => [],
+            };
+            const actual = getJSONForProperties(model, [favoritesPropName]);
+
+            const expected = {
+                [favoritesPropName]: favoritesValue,
+            };
+
+            expect(actual).toEqual(expected);
+        });
+    });
 });

--- a/src/model/helpers/json.js
+++ b/src/model/helpers/json.js
@@ -16,6 +16,7 @@ const NON_MODEL_COLLECTIONS = {
     deliveryChannels: ['programNotificationTemplate'],
     redirectUris: ['oAuth2Client'],
     organisationUnitLevels: ['validationRule'],
+    favorites: [],
 };
 
 const isNonModelCollection = (propertyName, modelType) => {


### PR DESCRIPTION
The favorites property will always be an array of strings, where the string is a userId.