### PR TITLE
ModelCollectionProperty isDirty to check for dirty values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2",
-  "version": "29.0.0",
+  "version": "29.0.1",
   "description": "Javascript library for DHIS2",
   "main": "d2.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build-only": "rm -rf lib/ && babel src --out-dir lib --source-maps --ignore __tests__,__fixtures__,__mocks__ && ./node_modules/webpack/bin/webpack.js && ./node_modules/webpack/bin/webpack.js --config webpack.config.min.js",
     "build": "npm run build-only",
     "lint": "./node_modules/eslint/bin/eslint.js src",
+    "lint-fix": "./node_modules/eslint/bin/eslint.js src --fix",
     "travis": "npm run coverage && npm run build"
   },
   "repository": {

--- a/src/model/ModelCollectionProperty.js
+++ b/src/model/ModelCollectionProperty.js
@@ -125,7 +125,11 @@ class ModelCollectionProperty extends ModelCollection {
      *
      * @returns {boolean} true if any elements have been added to or removed from the collection
      */
-    isDirty() {
+    isDirty(includeValues = true) {
+        if (includeValues) {
+            return this.dirty || this.toArray()
+                .filter(model => model && (model.isDirty() === true)).length > 0;
+        }
         return this.dirty;
     }
 

--- a/src/model/ModelCollectionProperty.js
+++ b/src/model/ModelCollectionProperty.js
@@ -122,7 +122,8 @@ class ModelCollectionProperty extends ModelCollection {
 
     /**
      * Checks if the collection property has been modified.
-     *
+     * @param {boolean} [includeValues=true] If true, also checks if any models in the collection
+     * has been edited by checking the dirty flag on each model.
      * @returns {boolean} true if any elements have been added to or removed from the collection
      */
     isDirty(includeValues = true) {

--- a/src/model/__tests__/ModelCollectionProperty.spec.js
+++ b/src/model/__tests__/ModelCollectionProperty.spec.js
@@ -24,7 +24,7 @@ describe('ModelCollectionProperty', () => {
 
         mcp = ModelCollectionProperty.create(mockParentModel, mockModelDefinition, 'dataElementGroups', []);
 
-        testModels.push(mockModelDefinition.create({ id: 'dataEleme01' }));
+        testModels.push(mockModelDefinition.create({ id: 'dataEleme01', name: 'Test' }));
         testModels.push(mockModelDefinition.create({ id: 'dataEleme02' }));
         testModels.push(mockModelDefinition.create({ id: 'dataEleme03' }));
     });
@@ -175,6 +175,32 @@ describe('ModelCollectionProperty', () => {
             expect(mcp.isDirty()).toBe(false);
             mcp.added.add(testModels[0]);
             expect(mcp.isDirty()).toBe(false);
+        });
+
+        it('Should be dirty=true if any model has been edited by default', () => {
+            expect(mcp.isDirty()).toBe(false);
+            mcp.add(testModels[0]);
+            expect(mcp.isDirty()).toBe(true);
+            mcp.resetDirtyState();
+
+            expect(mcp.isDirty()).toBe(false);
+
+            testModels[0].name = 'Birk';
+            expect(testModels[0].isDirty()).toBe(true);
+            expect(mcp.isDirty()).toBe(true);
+        });
+
+        it('Should be dirty=false if includeValues=false', () => {
+            expect(mcp.isDirty()).toBe(false);
+            mcp.add(testModels[0]);
+            expect(mcp.isDirty()).toBe(true);
+            mcp.resetDirtyState();
+
+            expect(mcp.isDirty()).toBe(false);
+
+            testModels[0].name = 'Birk';
+            expect(testModels[0].isDirty()).toBe(true);
+            expect(mcp.isDirty(false)).toBe(false);
         });
     });
 

--- a/src/model/__tests__/ModelCollectionProperty.spec.js
+++ b/src/model/__tests__/ModelCollectionProperty.spec.js
@@ -185,7 +185,7 @@ describe('ModelCollectionProperty', () => {
 
             expect(mcp.isDirty()).toBe(false);
 
-            testModels[0].name = 'Birk';
+            testModels[0].name = 'Raccoon';
             expect(testModels[0].isDirty()).toBe(true);
             expect(mcp.isDirty()).toBe(true);
         });
@@ -198,7 +198,7 @@ describe('ModelCollectionProperty', () => {
 
             expect(mcp.isDirty()).toBe(false);
 
-            testModels[0].name = 'Birk';
+            testModels[0].name = 'Raccoon';
             expect(testModels[0].isDirty()).toBe(true);
             expect(mcp.isDirty(false)).toBe(false);
         });


### PR DESCRIPTION
Enhanced isDirty() function on ModelCollectionProperty to by default also check for any dirty values inside the collection. This can be overridden by passing isDirty(false), and it will behave like the old way (only check for models added/removed from the collection).

