### PR TITLE
Create the `this.modelDefinition.modelValidations` in the constructor…

### DIFF
--- a/src/model/ModelBase.js
+++ b/src/model/ModelBase.js
@@ -18,6 +18,11 @@ export const DIRTY_PROPERTY_LIST = Symbol('List to keep track of dirty propertie
  * @memberof module:model
  */
 class ModelBase {
+    constructor() {
+        this.modelDefinition = {
+            modelValidations: {},
+        };
+    }
     /**
      * @returns {Promise} Returns a promise that resolves when the model has been saved or rejected with the result from
      * the `validate()` call.

--- a/src/model/__tests__/ModelBase.spec.js
+++ b/src/model/__tests__/ModelBase.spec.js
@@ -687,7 +687,7 @@ describe('ModelBase', () => {
 
         it('should not throw an exception on `toJSON` for base models', () => {
             expect(model.toJSON()).toEqual({});
-        })
+        });
 
         it('should return a json representation of the model', () => {
             model.modelDefinition = {

--- a/src/model/__tests__/ModelBase.spec.js
+++ b/src/model/__tests__/ModelBase.spec.js
@@ -679,6 +679,17 @@ describe('ModelBase', () => {
 
         beforeEach(() => {
             model = Object.create(modelBase);
+        });
+
+        it('should be a function', () => {
+            expect(typeof model.toJSON).toBe('function');
+        });
+
+        it('should not throw an exception on `toJSON` for base models', () => {
+            expect(model.toJSON()).toEqual({});
+        })
+
+        it('should return a json representation of the model', () => {
             model.modelDefinition = {
                 modelValidations: {
                     name: {
@@ -700,13 +711,6 @@ describe('ModelBase', () => {
 
             model.name = model.dataValues.name;
             model.dataElements = model.dataValues.dataElements;
-        });
-
-        it('should be a function', () => {
-            expect(typeof model.toJSON).toBe('function');
-        });
-
-        it('should return a json representation of the model', () => {
             const expected = ({
                 name: 'ANC',
                 dataElements: [


### PR DESCRIPTION
… for ModelBase

There can be instances where a ModelBase is used without a proper Model,
and in that case most of the prototype functions work correctly, except
for the ones which look up `modelDefinition` and beyond.

`toJSON` is one of these functions. The expected response should be an
empty object if the subclass doesn't have any members so creating this
basic structure in the constructor works around the heisenbug which
appears from time to time.