### PR TITLE
Add dataSetNotificationTemplate as non-model-collection

### DIFF
--- a/src/model/helpers/json.js
+++ b/src/model/helpers/json.js
@@ -13,7 +13,7 @@ const NON_MODEL_COLLECTIONS = {
     aggregationLevels: ['dataElement'],
     grantTypes: ['oAuth2Client'],
     translations: [],
-    deliveryChannels: ['programNotificationTemplate'],
+    deliveryChannels: ['programNotificationTemplate', 'dataSetNotificationTemplate'],
     redirectUris: ['oAuth2Client'],
     organisationUnitLevels: ['validationRule'],
     favorites: [],


### PR DESCRIPTION
When saving dataSetNotificationTemplates, an empty array is always returned as d2 think it's a collection. This should be sent "as-is" as an array.