### PR TITLE
Feature/filter token and root junction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2",
-  "version": "29.1.5",
+  "version": "30.0.0",
   "description": "Javascript library for DHIS2",
   "main": "d2.js",
   "scripts": {

--- a/src/lib/check.js
+++ b/src/lib/check.js
@@ -106,3 +106,19 @@ export const isNullUndefinedOrEmptyString = toBeAny([undefined, null, '']);
 export const isFunction = fun => typeof fun === 'function';
 
 export const hasOwnProperty = (object, propertyName) => Object.prototype.hasOwnProperty.call(object, propertyName);
+
+// The logical mode to use when having multiple filters.
+// Default is AND.
+// See https://docs.dhis2.org/master/en/developer/html/webapi_metadata_object_filter.html
+
+export const rootJunctions = ['OR', 'AND'];
+export const isValidRootJunction = toBeAny(rootJunctions);
+export function checkValidRootJunction(rootJunction) {
+    checkType(rootJunction, 'string', 'rootJunction');
+
+    if (isValidRootJunction(rootJunction)) {
+        return true;
+    }
+    throw new Error(`Expected ${rootJunction} to be one of [${rootJunctions}]`);
+}
+

--- a/src/model/Filter.js
+++ b/src/model/Filter.js
@@ -37,6 +37,26 @@ const FILTER_COMPARATORS = {
      * This method can be used to add a ne filter value
      */
     notEqual: 'ne',
+
+    /**
+     * @function
+     * @memberof module:model.Filter.prototype
+     * @returns {Filter} Returns the modified filter for chaining
+     *
+     * @description
+     * This method can be used to add a token filter value
+     */
+    token: 'token',
+
+    /**
+     * @function
+     * @memberof module:model.Filter.prototype
+     * @returns {Filter} Returns the modified filter for chaining
+     *
+     * @description
+     * This method can be used to add a !token filter value
+     */
+    nToken: '!token',
 };
 
 /**
@@ -94,6 +114,19 @@ class Filter {
      */
     static getFilter(addFilterCallback) {
         return new Filter(addFilterCallback);
+    }
+
+    /**
+     * Utility function to add an operator with filterValue
+     * @param {*} operator to use
+     * @param {*} filterValue to filter on
+     */
+    operator(operator, filterValue) {
+        checkDefined(operator, 'operator');
+        checkDefined(filterValue, 'filterValue');
+        this.comparator = operator;
+        this.filterValue = filterValue;
+        return this.addFilterCallback(this);
     }
 }
 

--- a/src/model/Filters.js
+++ b/src/model/Filters.js
@@ -100,15 +100,17 @@ class Filters {
 
     /**
      * The logic mode to use on the filters.
+     *
+     * Default behavior is AND.
      * Note that the logic will be used across all the filters, which
      * means with OR, results will be returned when any of the filter match.
      * It MUST be called last on the chain of filters when called 
      * through modelDefinition.filter().
-     * 
+     * @see {@link https://docs.dhis2.org/master/en/developer/html/webapi_metadata_object_filter.html|Object filter Docs }
      * @example
-     * d2.programs.filter().on('name').like('Child)
+     * d2.programs.filter().on('name').like('Child')
      * .filter().logicMode('OR').on('code').equals('Child')
-     * @param {*} junction The logic operator to use. One of ['OR', 'AND'];
+     * @param {string} junction The logic operator to use. One of ['OR', 'AND'];
      */
     logicMode(junction) {
         checkValidRootJunction(junction);

--- a/src/model/Filters.js
+++ b/src/model/Filters.js
@@ -1,4 +1,4 @@
-import { isType } from '../lib/check';
+import { isType, checkValidRootJunction } from '../lib/check';
 import { identity } from '../lib/utils';
 import Filter from '../model/Filter';
 
@@ -24,6 +24,7 @@ class Filters {
          */
         this.filters = filters;
         this.modelDefinition = modelDefinition;
+        this.rootJunction = null;
     }
 
     /**
@@ -95,6 +96,24 @@ class Filters {
      */
     getFilterList() {
         return this.filters.map(identity);
+    }
+
+    /**
+     * The logic mode to use on the filters.
+     * Note that the logic will be used across all the filters, which
+     * means with OR, results will be returned when any of the filter match.
+     * It MUST be called last on the chain of filters when called 
+     * through modelDefinition.filter().
+     * 
+     * @example
+     * d2.programs.filter().on('name').like('Child)
+     * .filter().logicMode('OR').on('code').equals('Child')
+     * @param {*} junction The logic operator to use. One of ['OR', 'AND'];
+     */
+    logicMode(junction) {
+        checkValidRootJunction(junction);
+        this.rootJunction = junction;
+        return this;
     }
 
     /**

--- a/src/model/ModelDefinition.js
+++ b/src/model/ModelDefinition.js
@@ -270,7 +270,8 @@ class ModelDefinition {
      */
     list(listParams = {}) {
         const { apiEndpoint, ...extraParams } = listParams;
-        const params = Object.assign({ fields: ':all' }, extraParams);
+        const definedRootJunction = this.filters.rootJunction ? { rootJunction: this.filters.rootJunction } : {};
+        const params = Object.assign({ fields: ':all' }, definedRootJunction, extraParams);
         const definedFilters = this.filters.getQueryFilterValues();
 
         if (!isDefined(params.filter)) {

--- a/src/model/__tests__/Filter.spec.js
+++ b/src/model/__tests__/Filter.spec.js
@@ -45,6 +45,14 @@ describe('Filter', () => {
                 expect(filter.equals).toBeInstanceOf(Function);
             });
 
+            it('should have a token method', () => {
+                expect(filter.token).toBeInstanceOf(Function);
+            });
+
+            it('should have a nToken method', () => {
+                expect(filter.nToken).toBeInstanceOf(Function);
+            });
+
             it('should set the correct comparator', () => {
                 filter.equals('ANC');
 

--- a/src/model/__tests__/Filters.spec.js
+++ b/src/model/__tests__/Filters.spec.js
@@ -110,4 +110,25 @@ describe('Filters', () => {
             expect(filters.getQueryFilterValues()).toEqual(['code:eq:Partner_453', 'name:like:John']);
         });
     });
+
+    describe('logicMode', () => {
+        let filters;
+
+        beforeEach(() => {
+            filters = new Filters();
+        });
+
+        it('should be a function', () => {
+            expect(filters.getQueryFilterValues).toBeInstanceOf(Function);
+        });
+
+        it('should throw when invalid rootJunction are given', () => {
+            expect(() => filters.logicMode('asf')).toThrow();
+        });
+
+        it('should set the rootJunction on the object', () => {
+            filters.logicMode('OR');
+            expect(filters.rootJunction).toEqual('OR');
+        });
+    });
 });

--- a/src/model/__tests__/ModelDefinition.spec.js
+++ b/src/model/__tests__/ModelDefinition.spec.js
@@ -805,11 +805,59 @@ describe('ModelDefinition', () => {
             expect(ModelDefinition.prototype.api.get).toBeCalledWith('https://play.dhis2.org/demo/api/dataElements', { fields: ':all', filter: ['name:like:John', 'username:eq:admin'] });
         });
 
+        it('should work with operator-filter', () => {
+            dataElementModelDefinition
+                .filter()
+                .on('name')
+                .operator('like', 'John')
+                .list();
+
+            expect(ModelDefinition.prototype.api.get).toBeCalledWith('https://play.dhis2.org/demo/api/dataElements', { fields: ':all', filter: ['name:like:John'] });
+        });
+
+        it('should work with chained operator-filter', () => {
+            dataElementModelDefinition
+                .filter()
+                .on('name')
+                .operator('like', 'John')
+                .filter()
+                .on('username')
+                .operator('token', 'admin')
+                .list();
+
+            expect(ModelDefinition.prototype.api.get).toBeCalledWith('https://play.dhis2.org/demo/api/dataElements', { fields: ':all', filter: ['name:like:John', 'username:token:admin'] });
+        });
+
+        it('should work with rootJunction', () => {
+            dataElementModelDefinition
+                .filter()
+                .logicMode('OR')
+                .on('name')
+                .like('John')
+                .filter()
+                .logicMode('OR')
+                .on('username')
+                .token('admin')
+                .list();
+
+            expect(ModelDefinition.prototype.api.get).toBeCalledWith('https://play.dhis2.org/demo/api/dataElements', { fields: ':all', filter: ['name:like:John', 'username:token:admin'], rootJunction: 'OR' });
+        });
+
         it('should not try to filter by "undefined"', () => {
             dataElementModelDefinition
                 .list({ filter: undefined });
 
             expect(ModelDefinition.prototype.api.get).toBeCalledWith('https://play.dhis2.org/demo/api/dataElements', { fields: ':all' });
+        });
+
+        it('should work by constructing filters before calling list', () => {
+            const filters = dataElementModelDefinition.filter();
+            filters.logicMode('OR');
+            filters.on('name').like('John');
+            filters.on('username').token('admin');
+            filters.list();
+
+            expect(ModelDefinition.prototype.api.get).toBeCalledWith('https://play.dhis2.org/demo/api/dataElements', { fields: ':all', filter: ['name:like:John', 'username:token:admin'], rootJunction: 'OR' });
         });
     });
 

--- a/src/model/__tests__/__snapshots__/ModelDefinition.spec.js.snap
+++ b/src/model/__tests__/__snapshots__/ModelDefinition.spec.js.snap
@@ -57,6 +57,7 @@ Array [
     "filters": Filters {
       "filters": Array [],
       "modelDefinition": [Circular],
+      "rootJunction": null,
     },
     "getOwnedPropertyJSON": [Function],
     "identifiableObject": true,
@@ -985,6 +986,7 @@ Array [
     "filters": Filters {
       "filters": Array [],
       "modelDefinition": [Circular],
+      "rootJunction": null,
     },
     "getOwnedPropertyJSON": [Function],
     "identifiableObject": true,


### PR DESCRIPTION
This adds the ability to use the "rootJunction"-query on the API to be able to use "OR"-logic when filtering.

Also adds the new "token" filter.

Updates to v30.0.0 as its a new feature on the backend.