### PR TITLE
Feature/.update() - send payload data with text/plain option present [DHIS2-3430]

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -181,8 +181,12 @@ class Api {
         // Since we are currently using PUT to save the full state back, we have to use mergeMode=REPLACE
         // to clear out existing values
         const urlForUpdate = useMergeStrategy === true ? `${url}?${getMergeStrategyParam()}` : url;
-        return this.request('PUT', getUrl(this.baseUrl, urlForUpdate), String(data),
-            { headers: new Headers({ 'Content-Type': 'text/plain' }) });
+        if (typeof data === 'string') {
+            return this.request('PUT', getUrl(this.baseUrl, urlForUpdate), String(data),
+                { headers: new Headers({ 'Content-Type': 'text/plain' }) });
+        }
+
+        return this.request('PUT', getUrl(this.baseUrl, urlForUpdate), JSON.stringify(data));
     }
 
     /**

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -182,6 +182,9 @@ class Api {
         // to clear out existing values
         const urlForUpdate = useMergeStrategy === true ? `${url}?${getMergeStrategyParam()}` : url;
 
+        if (typeof data === 'string') {
+            return this.request('PUT', getUrl(this.baseUrl, urlForUpdate), data);
+        }
         return this.request('PUT', getUrl(this.baseUrl, urlForUpdate), JSON.stringify(data));
     }
 

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -181,11 +181,8 @@ class Api {
         // Since we are currently using PUT to save the full state back, we have to use mergeMode=REPLACE
         // to clear out existing values
         const urlForUpdate = useMergeStrategy === true ? `${url}?${getMergeStrategyParam()}` : url;
-
-        if (typeof data === 'string') {
-            return this.request('PUT', getUrl(this.baseUrl, urlForUpdate), data);
-        }
-        return this.request('PUT', getUrl(this.baseUrl, urlForUpdate), JSON.stringify(data));
+        return this.request('PUT', getUrl(this.baseUrl, urlForUpdate), String(data),
+            { headers: new Headers({ 'Content-Type': 'text/plain' }) });
     }
 
     /**

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -552,8 +552,8 @@ describe('Api', () => {
                 '/api/some/fake/api/endpoint',
                 Object.assign(baseFetchOptions, {
                     method: 'PUT',
-                    headers: new Headers({ 'Content-Type': 'text/plain' }),
-                    body: String(data),
+                    headers: new Headers({ 'Content-Type': 'application/json' }),
+                    body: JSON.stringify(data),
                 }),
             );
         });
@@ -562,12 +562,12 @@ describe('Api', () => {
             api.update('some/fake/api/endpoint', {}, true);
 
             const fetchOptions = {
-                body: String({}),
+                body: '{}',
                 cache: 'default',
                 credentials: 'include',
                 headers: {
                     map: {
-                        'content-type': 'text/plain',
+                        'content-type': 'application/json',
                     },
                 },
                 method: 'PUT',
@@ -589,17 +589,39 @@ describe('Api', () => {
             api.update('some/fake/api/endpoint', {}, true);
 
             const fetchOptions = {
-                body: String({}),
+                body: '{}',
                 cache: 'default',
                 credentials: 'include',
                 headers: {
-                    map: { 'content-type': 'text/plain' },
+                    map: { 'content-type': 'application/json' },
                 },
                 method: 'PUT',
                 mode: 'cors',
             };
 
             expect(fetchMock).toBeCalledWith('/api/some/fake/api/endpoint?mergeStrategy=REPLACE', fetchOptions);
+        });
+
+        it('should support payloads of plain texts', () => {
+            const data = {
+                a: 'A',
+                b: 'B!',
+                obj: {
+                    oa: 'o.a',
+                    ob: 'o.b',
+                },
+                arr: [1, 2, 3],
+            };
+            api.update('some/fake/api/endpoint', JSON.stringify(data));
+
+            expect(fetchMock).toBeCalledWith(
+                '/api/some/fake/api/endpoint',
+                Object.assign(baseFetchOptions, {
+                    method: 'PUT',
+                    headers: new Headers({ 'Content-Type': 'text/plain' }),
+                    body: JSON.stringify(data),
+                }),
+            );
         });
     });
 

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -552,8 +552,8 @@ describe('Api', () => {
                 '/api/some/fake/api/endpoint',
                 Object.assign(baseFetchOptions, {
                     method: 'PUT',
-                    headers: new Headers({ 'Content-Type': 'application/json' }),
-                    body: JSON.stringify(data),
+                    headers: new Headers({ 'Content-Type': 'text/plain' }),
+                    body: String(data),
                 }),
             );
         });
@@ -562,12 +562,12 @@ describe('Api', () => {
             api.update('some/fake/api/endpoint', {}, true);
 
             const fetchOptions = {
-                body: '{}',
+                body: String({}),
                 cache: 'default',
                 credentials: 'include',
                 headers: {
                     map: {
-                        'content-type': 'application/json',
+                        'content-type': 'text/plain',
                     },
                 },
                 method: 'PUT',
@@ -589,11 +589,11 @@ describe('Api', () => {
             api.update('some/fake/api/endpoint', {}, true);
 
             const fetchOptions = {
-                body: '{}',
+                body: String({}),
                 cache: 'default',
                 credentials: 'include',
                 headers: {
-                    map: { 'content-type': 'application/json' },
+                    map: { 'content-type': 'text/plain' },
                 },
                 method: 'PUT',
                 mode: 'cors',


### PR DESCRIPTION
This feature enables editing interpretation comments, by updating the API endpoint through **d2.Api.getApi().update()**, with plain text strings.

JIRA ticket: https://jira.dhis2.org/browse/DHIS2-3430
PR: https://github.com/dhis2/dashboards-app/pull/191

The payload when editing an interpretation comment will always be a string, but the update() function performs the PUT request with the default option application/json - resulting in stringify'ing a string, leaving extra quotation marks (which the Regex will fail to filter out).

The tests for .update() have also been changed to expect the body as a string, and option sent with content.type: text/plain (The tests still call the functions with an object as payload parameter, which is consistent with the documentation).
