### PR TITLE
Analytics request .withParameters() method

### DIFF
--- a/src/analytics/AnalyticsRequestPropertiesMixin.js
+++ b/src/analytics/AnalyticsRequestPropertiesMixin.js
@@ -20,6 +20,28 @@ const AnalyticsRequestPropertiesMixin = base =>
      */
     class extends base {
         /**
+         * Sets the query parameters of the request
+         *
+         * @param {!Object} parameters The query parameters to add/modify to the request
+         *
+         * @returns {AnalyticsRequest} A new instance of the class for chaining purposes
+         *
+         * @example
+         * const req = new d2.analytics.request()
+         *   .withParameters({ completedOnly: true, aggregationType: 'AVERAGE' });
+         */
+        withParameters(params) {
+            if (params) {
+                this.parameters = {
+                    ...this.parameters,
+                    ...params,
+                };
+            }
+
+            return new AnalyticsRequest(this);
+        }
+
+        /**
          * Sets the URL path for the request.
          * It appends the given path to the request's URL.
          *

--- a/src/analytics/__tests__/AnalyticsRequest.spec.js
+++ b/src/analytics/__tests__/AnalyticsRequest.spec.js
@@ -264,6 +264,29 @@ describe('AnalyticsRequest', () => {
             });
         });
 
+        describe('.withParameters()', () => {
+            const params = {
+                completedOnly: true,
+                aggregationType: 'AVERAGE',
+            };
+
+            it('should set the given parameters in the request', () => {
+                request.withParameters(params);
+
+                expect(request.parameters).toEqual(params);
+            });
+
+            it('should override a parameter if already present', () => {
+                request = request.withAggregationType('COUNT');
+
+                expect(request.parameters).toEqual({ aggregationType: 'COUNT' });
+
+                request = request.withParameters(params);
+
+                expect(request.parameters).toEqual(params);
+            });
+        });
+
         describe('with boolean parameter', () => {
             [
                 'aggregateData',


### PR DESCRIPTION
This method allows to pass an object with query string parameters to pass to the analytics request.
Handy for setting multiple parameters at once, instead of chaining each .with* method.
