### PR TITLE
Treat interpretations as non collection for chart models

### DIFF
--- a/src/model/helpers/json.js
+++ b/src/model/helpers/json.js
@@ -21,6 +21,7 @@ const NON_MODEL_COLLECTIONS = {
     rows: [],
     filters: [],
     yearlySeries: [],
+    interpretations: ['chart'],
 };
 
 const isNonModelCollection = (propertyName, modelType) => {


### PR DESCRIPTION
This is to allow `interpretation.created` to end up in the JSON object when `chartModel.toJSON` is called. 