### PR TITLE
fix: Move development dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   },
   "homepage": "https://github.com/dhis2/d2",
   "dependencies": {
-    "docdash": "^0.4.0",
-    "jsdoc": "^3.5.5",
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
@@ -45,11 +43,13 @@
     "babel-preset-stage-2": "^6.18.0",
     "canonical-path": "0.0.2",
     "codeclimate-test-reporter": "^0.4.1",
+    "docdash": "^0.4.0",
     "eslint-config-dhis2": "^3.0.2",
     "esprima": "^3.1.3",
     "form-data": "^2.1.2",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^21.0.2",
+    "jsdoc": "^3.5.5",
     "karma-cli": "^1.0.1",
     "lodash": "^4.17.4",
     "node-fetch": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/dhis2/d2",
   "dependencies": {
-    "babel-jest": "^22.4.3",
     "docdash": "^0.4.0",
     "jsdoc": "^3.5.5",
     "whatwg-fetch": "^2.0.3"
@@ -39,6 +38,7 @@
     "babel-cli": "^6.24.0",
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.2.3",
+    "babel-jest": "^22.4.3",
     "babel-loader": "^7.0.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.24.0",


### PR DESCRIPTION
The development dependency `babel-jest` was incorrectly added to `dependencies`.  This doesn't play well with `react-scripts` >= 2.0 which requires singular `babel-jest` dependency at version `23.6.0`:

```
The react-scripts package provided by Create React App requires a dependency:

  "babel-jest": "23.6.0"

Don't try to install it manually: your package manager does it automatically.
However, a different version of babel-jest was detected higher up in the tree:
```