### PR TITLE
Enforce encoding for all API requests

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -229,14 +229,25 @@ class Api {
             requestUrl = requestUrl.substr(0, requestUrl.indexOf('?'));
         }
 
+        // Encode existing query parameters, since tomcat does not accept unencoded brackets. Throw
+        // an error if they're already encoded to prevent double encoding.
+        if (query) {
+            const isEncoded = query !== decodeURIComponent(query);
+
+            if (isEncoded) {
+                throw new Error('Cannot process URL encoded URLs, pass an unencoded URL');
+            }
+
+            query = customEncodeURIComponent(query);
+        }
+
         // Transfer filter properties from the data object to the query string
         if (data && Array.isArray(data.filter)) {
             const encodedFilters = data.filter
                 .map(filter => filter.split(':').map(encodeURIComponent).join(':'));
 
             query = (
-                `${customEncodeURIComponent(query)}${query.length ? '&' : ''}` +
-                `filter=${encodedFilters.join('&filter=')}`
+                `${query}${query.length ? '&' : ''}filter=${encodedFilters.join('&filter=')}`
             );
             delete data.filter; // eslint-disable-line no-param-reassign
         }

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -235,7 +235,9 @@ class Api {
             const isEncoded = query !== decodeURIComponent(query);
 
             if (isEncoded) {
-                throw new Error('Cannot process URL encoded URLs, pass an unencoded URL');
+                return Promise.reject(
+                    new Error('Cannot process URL encoded URLs, pass an unencoded URL'),
+                );
             }
 
             query = customEncodeURIComponent(query);

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -232,7 +232,15 @@ class Api {
         // Encode existing query parameters, since tomcat does not accept unencoded brackets. Throw
         // an error if they're already encoded to prevent double encoding.
         if (query) {
-            const isEncoded = query !== decodeURIComponent(query);
+            let decodedURL;
+
+            try {
+                decodedURL = decodeURIComponent(query);
+            } catch (err) {
+                return Promise.reject(new Error('Query parameters in URL are invalid'));
+            }
+
+            const isEncoded = query !== decodedURL;
 
             if (isEncoded) {
                 return Promise.reject(

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -244,7 +244,7 @@ class Api {
 
             if (isEncoded) {
                 return Promise.reject(
-                    new Error('Cannot process URL encoded URLs, pass an unencoded URL'),
+                    new Error('Cannot process URL-encoded URLs, pass an unencoded URL'),
                 );
             }
 

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -40,7 +40,7 @@ function getUrl(baseUrl, url) {
  * Used for interaction with the dhis2 api.
  *
  * This class is used as the backbone for d2 and handles all the interaction with the server. There is a singleton
- * available to be reused across your applications. The singleton can be grabbed from the d2 instance.
+ * available to be reused across your applications. The singleton can be grabbed from the d2 instance. The api methods all handle URL-encoding for you, so you can just pass them unencoded strings
  *
  * ```js
  * import { getInstance } from 'd2/lib/d2';
@@ -102,8 +102,8 @@ class Api {
     /**
      * Performs a GET request.
      *
-     * @param {string} url The url for the request
-     * @param {*} data Any data that should be send with the request. For a GET request these are turned into
+     * @param {string} url The url for the request, should be unencoded. Will return a rejected promise for malformed urls and urls that contain encoded query strings.
+     * @param {*} data Any data that should be sent with the request. For a GET request these are encoded and turned into
      * query parameters. For POST and PUT requests it becomes the body.
      * @param {Object.<string, any>} options The request options are passed as options to the fetch request.
      * These options are passed as the {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters|init}

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -257,6 +257,18 @@ describe('Api', () => {
                 });
         });
 
+        it('should reject with an error when url is malformed', (done) => {
+            const message = 'Query parameters in URL are invalid';
+
+            api.get('test?%5')
+                .then(() => done(new Error('The request should error')))
+                .catch((err) => {
+                    expect(err).toBeInstanceOf(Error);
+                    expect(err.message).toBe(message);
+                    done();
+                });
+        });
+
         it('should not break URIs when encoding', (done) => {
             api.get('test?a=b=c&df,gh')
                 .then(() => {

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -245,7 +245,7 @@ describe('Api', () => {
                 .catch(done);
         });
 
-        it.only('should reject with an error when url contains encoded query string', (done) => {
+        it('should reject with an error when url contains encoded query string', (done) => {
             const message = 'Cannot process URL encoded URLs, pass an unencoded URL';
 
             api.get('test?one=%5Bwith%20a%20filter%5D')

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -234,7 +234,7 @@ describe('Api', () => {
                     expect(fetchMock).toHaveBeenCalledWith([
                         '/api/some/endpoint?',
                         'a=b&',
-                        'c=d|e&',
+                        'c=d%7Ce&',
                         'f=g%7Ch%5Bi%2Cj%5D%2Ck%5Bl%7Cm%5D%2Cn%7Bo~p%60q%60%24r%40s!t%7D&',
                         'u=-._~%3A%2F%3F%23%5B%5D%40!%24%26()*%2B%2C%3B%3D%3D%3D%2C~%24!%40*()_-%3D%2B%2F%3B%3A',
                     ].join(''),

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -246,7 +246,7 @@ describe('Api', () => {
         });
 
         it('should reject with an error when url contains encoded query string', (done) => {
-            const message = 'Cannot process URL encoded URLs, pass an unencoded URL';
+            const message = 'Cannot process URL-encoded URLs, pass an unencoded URL';
 
             api.get('test?one=%5Bwith%20a%20filter%5D')
                 .then(() => done(new Error('The request should error')))

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -245,6 +245,18 @@ describe('Api', () => {
                 .catch(done);
         });
 
+        it.only('should reject with an error when url contains encoded query string', (done) => {
+            const message = 'Cannot process URL encoded URLs, pass an unencoded URL';
+
+            api.get('test?one=%5Bwith%20a%20filter%5D')
+                .then(() => done(new Error('The request should error')))
+                .catch((err) => {
+                    expect(err).toBeInstanceOf(Error);
+                    expect(err.message).toBe(message);
+                    done();
+                });
+        });
+
         it('should not break URIs when encoding', (done) => {
             api.get('test?a=b=c&df,gh')
                 .then(() => {

--- a/src/api/__tests__/api.spec.js
+++ b/src/api/__tests__/api.spec.js
@@ -226,7 +226,7 @@ describe('Api', () => {
         });
 
         it('should properly encode URIs', (done) => {
-            api.get('some/endpoint?a=b&c=d|e', {
+            api.get('some/endpoint?a=b&c=d|e[with:filter]', {
                 f: 'g|h[i,j],k[l|m],n{o~p`q`$r@s!t}',
                 u: '-._~:/?#[]@!$&()*+,;===,~$!@*()_-=+/;:',
             })
@@ -234,7 +234,7 @@ describe('Api', () => {
                     expect(fetchMock).toHaveBeenCalledWith([
                         '/api/some/endpoint?',
                         'a=b&',
-                        'c=d%7Ce&',
+                        'c=d%7Ce%5Bwith:filter%5D&',
                         'f=g%7Ch%5Bi%2Cj%5D%2Ck%5Bl%7Cm%5D%2Cn%7Bo~p%60q%60%24r%40s!t%7D&',
                         'u=-._~%3A%2F%3F%23%5B%5D%40!%24%26()*%2B%2C%3B%3D%3D%3D%2C~%24!%40*()_-%3D%2B%2F%3B%3A',
                     ].join(''),


### PR DESCRIPTION
Since tomcat 8.5 does not accept unencoded brackets, this PR enforces encoding by encoding pre-existing query strings as well. D2 already did this sometimes, but not always (if `data` wasn't passed it would leave `query` untouched).

To prevent double encoding it errors for already encoded query strings (previously this wasn't checked, so it's a breaking change).

Issue: https://jira.dhis2.org/browse/DHIS2-5081