### PR TITLE
Period parser support for bi-weekly periods

### DIFF
--- a/src/period/__tests__/parser_spec.js
+++ b/src/period/__tests__/parser_spec.js
@@ -24,6 +24,12 @@ const periodFixtures = {
     '2017ThuW4': makePeriodFixture('2017ThuW4', '2017 W4 January 26 - February 1', '2017-01-26', '2017-02-01'),
     '2017SatW4': makePeriodFixture('2017SatW4', '2017 W4 January 21 - 27', '2017-01-21', '2017-01-27'),
     '2017SunW4': makePeriodFixture('2017SunW4', '2017 W4 January 22 - 28', '2017-01-22', '2017-01-28'),
+    // BiWeekly
+    '2019BiW12': makePeriodFixture('2019BiW12', '2019 BiWeek 12 June 3 - 16', '2019-06-03', '2019-06-16'),
+    '2019BiW04': makePeriodFixture('2019BiW4', '2019 BiWeek 4 February 11 - 24', '2019-02-11', '2019-02-24'),
+    '2015BiW1': makePeriodFixture('2015BiW1', '2015 BiWeek 1 December 29 - January 11', '2014-12-29', '2015-01-11'),
+    '2016BiW27': makePeriodFixture('2017BiW1', '2017 BiWeek 1 January 2 - 15', '2017-01-02', '2017-01-15'),
+    '2015BiW27': makePeriodFixture('2015BiW27', '2015 BiWeek 27 December 28 - January 10', '2015-12-28', '2016-01-10'),
     // Monthly
     198103: makePeriodFixture('198103', 'March 1981', '1981-03-01', '1981-03-31'),
     198002: makePeriodFixture('198002', 'February 1980', '1980-02-01', '1980-02-29'),
@@ -116,6 +122,29 @@ describe('getPeriodFromPeriodId(periodId, locale) period parser', () => {
         });
         it('should handle Weekly Sunday period types', () => {
             doPeriodTest('2017SunW4');
+        });
+    });
+    describe('for BiWeekly periods', () => {
+        it('should handle valid BiWeekly periods', () => {
+            doPeriodTest('2019BiW12');
+        });
+        it('should handle BiWeek 1-9 with leading zero', () => {
+            doPeriodTest('2019BiW04');
+        });
+        it('should handle BiWeek 1 that starts the previous year', () => {
+            doPeriodTest('2015BiW1');
+        });
+        it('should handle BiWeek 27 for 52-week years', () => {
+            doPeriodTest('2016BiW27');
+        });
+        it('should handle BiWeek 27 for 53-week years', () => {
+            doPeriodTest('2015BiW27');
+        });
+        it('should not accept BiWeek numbers higher than 27', () => {
+            expect(() => getPeriodFromPeriodId('2017BiW28')).toThrowError();
+        });
+        it('should not accept BiWeek numbers below 1', () => {
+            expect(() => getPeriodFromPeriodId('2017BiW0')).toThrowError();
         });
     });
     describe('for Monthly periods', () => {

--- a/src/period/helpers.js
+++ b/src/period/helpers.js
@@ -149,3 +149,35 @@ export function getFirstDateOfWeek(year, week) {
 
     return new Date(year, month, ordDate - ordDiff[month]);
 }
+
+export const computeWeekBasedPeriod = ({ year, week, locale = 'en', weekTypeDiff = 0, periodLength = 6 }) => {
+    const startDate = addDays(weekTypeDiff, getFirstDateOfWeek(year, week));
+    const monthNames = getMonthNamesForLocale(locale);
+    const startMonth = startDate.getMonth();
+    const startYear = startDate.getFullYear();
+    const startMonthName = monthNames[startMonth];
+    const startDayNum = startDate.getDate();
+
+    if (week === 53 && startYear !== year) {
+        /* eslint-disable no-param-reassign */
+        week = 1;
+        year = startYear;
+        /* eslint-enable */
+    }
+
+    const endDate = addDays(periodLength, startDate);
+    const endMonth = endDate.getMonth();
+    const endDayNum = endDate.getDate();
+    const endMonthName = monthNames[endMonth];
+
+    return {
+        week,
+        year,
+        startMonthName,
+        startDayNum,
+        endMonthName,
+        endDayNum,
+        startDate: formatAsISODate(startDate),
+        endDate: formatAsISODate(endDate),
+    };
+};

--- a/src/period/helpers.js
+++ b/src/period/helpers.js
@@ -150,6 +150,24 @@ export function getFirstDateOfWeek(year, week) {
     return new Date(year, month, ordDate - ordDiff[month]);
 }
 
+/**
+ * This function takes some general instructions for a period and returns a precise period containing
+ * a start date and end date. It corrects for week 1 starting in a previous year and for week 53 in a
+ * 52 week year
+ * It is used by the BiWeekly periodType and all flavors of Weekly PeriodTypes,
+ * such as Weekly, weeklyWednessday, etc.
+ * @param {Object} obj - An object
+ * @param {Number} obj.year - Year
+ * @param {Number} obj.week - Week number between 1-53
+ * @param {String} [obj.locale=en] - The current locale
+ * @param {Number} [obj.weekTypeDiff=0] - The difference between the starting day of the week 
+ * in a given periodType and the first day of the week. This option is being used for different
+ * flavors of weekly period types, such as WeeklyWednesday, WeeklyThursday, etc.
+ * @param {Number} [obj.periodLength=6] - The amount of days until the end date: 6 for weekly 
+ * and 13 for Bikweekly
+ * @returns {Object} - An object containing various properties that can be used to contruct
+ * the final parsed period
+ */
 export const computeWeekBasedPeriod = ({ year, week, locale = 'en', weekTypeDiff = 0, periodLength = 6 }) => {
     const startDate = addDays(weekTypeDiff, getFirstDateOfWeek(year, week));
     const monthNames = getMonthNamesForLocale(locale);

--- a/src/period/helpers.js
+++ b/src/period/helpers.js
@@ -167,6 +167,30 @@ export function getFirstDateOfWeek(year, week) {
  * and 13 for Bikweekly
  * @returns {Object} - An object containing various properties that can be used to contruct
  * the final parsed period
+ * @example for default scenario
+ * computeWeekBasedPeriod({ year: 2019, week: 12})
+ * // returns:
+ * // {
+ * //     week: 12,
+ * //     year: 2019,
+ * //     startMonthName: 'June',
+ * //     startDayNumber: 3,
+ * //     endDayNumber: 9,
+ * //     startDate: '2019-06-03',
+ * //     endDate: '2019-06-09',
+ * // }
+ * @example for week 53 in 52 week year edge case
+ * computeWeekBasedPeriod({ year: 2016, week: 53})
+ * // returns:
+ * // {
+ * //     week: 1,
+ * //     year: 2017,
+ * //     startMonthName: 'January',
+ * //     startDayNumber: 2,
+ * //     endDayNumber: 8,
+ * //     startDate: '2017-01-02',
+ * //     endDate: '2017-01-08',
+ * // }
  */
 export const computeWeekBasedPeriod = ({ year, week, locale = 'en', weekTypeDiff = 0, periodLength = 6 }) => {
     const startDate = addDays(weekTypeDiff, getFirstDateOfWeek(year, week));

--- a/src/period/parser.js
+++ b/src/period/parser.js
@@ -16,6 +16,7 @@ const periodTypeRegex = {
     WeeklyThursday: /^([0-9]{4})(Thu)W([0-9]{1,2})$/,   // YYYY"ThuW"[1-53]
     WeeklySaturday: /^([0-9]{4})(Sat)W([0-9]{1,2})$/,   // YYYY"SatW"[1-53]
     WeeklySunday: /^([0-9]{4})(Sun)W([0-9]{1,2})$/,     // YYYY"SunW"[1-53]
+    BiWeekly: /^([0-9]{4})BiW([0-9]{1,2})$/,            // YYYY"BiW"[1-27]
     Monthly: /^([0-9]{4})([0-9]{2})$/,                  // YYYYMM
     BiMonthly: /^([0-9]{4})([0-9]{2})B$/,               // YYYY0[1-6]"B"
     Quarterly: /^([0-9]{4})Q([1234])$/,                 // YYYY"Q"[1-4]
@@ -27,16 +28,47 @@ const periodTypeRegex = {
     FinancialOct: /^([0-9]{4})Oct$/,                    // YYYY"Oct"
 };
 
+const computeWeekBasedPeriod = ({ year, week, locale = 'en', weekTypeDiff = 0, periodLength = 6 }) => {
+    const startDate = addDays(weekTypeDiff, getFirstDateOfWeek(year, week));
+    const monthNames = getMonthNamesForLocale(locale);
+    const startMonth = startDate.getMonth();
+    const startYear = startDate.getFullYear();
+    const startMonthName = monthNames[startMonth];
+    const startDayNum = startDate.getDate();
+
+    if (week === 53 && startYear !== year) {
+        /* eslint-disable no-param-reassign */
+        week = 1;
+        year = startYear;
+        /* eslint-enable */
+    }
+
+    const endDate = addDays(periodLength, startDate);
+    const endMonth = endDate.getMonth();
+    const endDayNum = endDate.getDate();
+    const endMonthName = monthNames[endMonth];
+
+    return {
+        week,
+        year,
+        startMonthName,
+        startDayNum,
+        endMonthName,
+        endDayNum,
+        startDate: formatAsISODate(startDate),
+        endDate: formatAsISODate(endDate),
+    };
+};
+
 /* eslint-disable complexity */
 const weeklyMatcherParser = (match, locale = 'en') => {
-    let year = parseInt(match[1], 10);
+    const year = parseInt(match[1], 10);
     const weekType = match[2];
-    let week = parseInt(match[3], 10);
+    const week = parseInt(match[3], 10);
+
     if (week < 1 || week > 53) {
         throw new Error('Invalid week number');
     }
-
-    const monthNames = getMonthNamesForLocale(locale);
 
     let weekTypeDiff = 0;
     switch (weekType) {
@@ -47,32 +79,17 @@ const weeklyMatcherParser = (match, locale = 'en') => {
     default: break;
     }
 
-    const startDate = addDays(weekTypeDiff, getFirstDateOfWeek(year, week));
-    const startMonth = startDate.getMonth();
-    const startYear = startDate.getFullYear();
-    const startMonthName = monthNames[startMonth];
-    const startDayNum = startDate.getDate();
+    const p = computeWeekBasedPeriod({ year, week, locale, weekTypeDiff });
 
-    if (week === 53 && startYear !== year) {
-        week = 1;
-        year = startYear;
-    }
-    const id = `${year}${weekType}W${week}`;
-
-    const endDate = addDays(6, startDate);
-    const endMonth = endDate.getMonth();
-    const endDayNum = endDate.getDate();
-    const endMonthName = monthNames[endMonth];
-
-    const name = startMonth === endMonth
-        ? `${year} W${week} ${startMonthName} ${startDayNum} - ${endDayNum}`
-        : `${year} W${week} ${startMonthName} ${startDayNum} - ${endMonthName} ${endDayNum}`;
+    const name = p.startMonthName === p.endMonthName
+        ? `${p.year} W${p.week} ${p.startMonthName} ${p.startDayNum} - ${p.endDayNum}`
+        : `${p.year} W${p.week} ${p.startMonthName} ${p.startDayNum} - ${p.endMonthName} ${p.endDayNum}`;
 
     return {
-        id,
+        id: `${p.year}${weekType}W${p.week}`,
         name,
-        startDate: formatAsISODate(startDate),
-        endDate: formatAsISODate(endDate),
+        startDate: p.startDate,
+        endDate: p.endDate,
     };
 };
 
@@ -103,6 +120,29 @@ const regexMatchToPeriod = {
     WeeklyThursday: weeklyMatcherParser,
     WeeklySaturday: weeklyMatcherParser,
     WeeklySunday: weeklyMatcherParser,
+    BiWeekly: (match, locale = 'en') => {
+        const year = parseInt(match[1], 10);
+        let biWeek = parseInt(match[2], 10);
+
+        if (biWeek < 1 || biWeek > 27) {
+            throw new Error('Invalid BiWeek number');
+        }
+
+        const week = (biWeek * 2) - 1;
+        const p = computeWeekBasedPeriod({ year, week, locale, periodLength: 13 });
+        biWeek = (p.week + 1) / 2;
+
+        const name = p.startMonthName === p.endMonthName
+            ? `${p.year} BiWeek ${biWeek} ${p.startMonthName} ${p.startDayNum} - ${p.endDayNum}`
+            : `${p.year} BiWeek ${biWeek} ${p.startMonthName} ${p.startDayNum} - ${p.endMonthName} ${p.endDayNum}`;
+
+        return {
+            id: `${p.year}BiW${biWeek}`,
+            name,
+            startDate: p.startDate,
+            endDate: p.endDate,
+        };
+    },
     Monthly: (match, locale = 'en') => {
         const id = match[0];
         const year = parseInt(match[1], 10);

--- a/src/period/parser.js
+++ b/src/period/parser.js
@@ -4,8 +4,7 @@ import {
     getLastDateOfMonth,
     getFirstDateOfQuarter,
     getLastDateOfQuarter,
-    getFirstDateOfWeek,
-    addDays,
+    computeWeekBasedPeriod,
 } from './helpers';
 import { toLocaleDayFormat } from './formatters';
 
@@ -26,38 +25,6 @@ const periodTypeRegex = {
     FinancialApril: /^([0-9]{4})April$/,                // YYYY"April"
     FinancialJuly: /^([0-9]{4})July$/,                  // YYYY"July"
     FinancialOct: /^([0-9]{4})Oct$/,                    // YYYY"Oct"
-};
-
-const computeWeekBasedPeriod = ({ year, week, locale = 'en', weekTypeDiff = 0, periodLength = 6 }) => {
-    const startDate = addDays(weekTypeDiff, getFirstDateOfWeek(year, week));
-    const monthNames = getMonthNamesForLocale(locale);
-    const startMonth = startDate.getMonth();
-    const startYear = startDate.getFullYear();
-    const startMonthName = monthNames[startMonth];
-    const startDayNum = startDate.getDate();
-
-    if (week === 53 && startYear !== year) {
-        /* eslint-disable no-param-reassign */
-        week = 1;
-        year = startYear;
-        /* eslint-enable */
-    }
-
-    const endDate = addDays(periodLength, startDate);
-    const endMonth = endDate.getMonth();
-    const endDayNum = endDate.getDate();
-    const endMonthName = monthNames[endMonth];
-
-    return {
-        week,
-        year,
-        startMonthName,
-        startDayNum,
-        endMonthName,
-        endDayNum,
-        startDate: formatAsISODate(startDate),
-        endDate: formatAsISODate(endDate),
-    };
 };
 
 /* eslint-disable complexity */


### PR DESCRIPTION
The d2-period-parser is being used internally by the d2-ui PeriodPicker component, so this needs support for BiWeekly periods too.

BiWeekly and Weekly periodTypes have a lot in common. So to keep things DRY, I extracted some logic from `weeklyMatcherParser` and moved it into `computeWeekBasedPeriod`. It is perhaps not the most elegant solution, because `computeWeekBasedPeriod` has to return a lot of properties to the calling function. So if you see any room for improvement there, that would be nice.