### PR TITLE
chore: update changelog in preparation of 31.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # D2 Changelog
 
-## Upcoming version
-###### _unreleased_
+## 31.5.0
+###### _February 28th 2019_
 
 **Breaking changes:**
 
 - Changed from babel `es2015` and `stage-2` presets to `babel-preset-env`, so for certain browsers support might have changed. Though currently the support is aligned with our supported browsers.
+
+**Bugfix:**
+
+- Fixed usage of isomorphic-fetch, to allow for usage of d2 in node and the browser.
 
 ## 30.1.0
 ###### _February 15th 2019_


### PR DESCRIPTION
In looking back at the previous changelog note I'm a bit confused as to why we put the breaking change of enforcing encoded API requests under 30.1.0. It was also backported 28.4.0 and 31.3.0. Bit confusing.

So to anyone reviewing this, the sudden jump from 30.1.0 to 31.5.0 is not a single version bump, but because the version bumps in between are not in the changelog.