### PR TITLE
Fix: respect request instance include num den in get

### DIFF
--- a/src/analytics/AnalyticsBase.js
+++ b/src/analytics/AnalyticsBase.js
@@ -53,7 +53,7 @@ class AnalyticsBase {
         const dataReq = new AnalyticsRequest(req)
             .withSkipData(false)
             .withSkipMeta(true)
-            .withIncludeNumDen()
+            .withIncludeNumDen(req.parameters.includeNumDen)
             .withDisplayProperty('SHORTNAME');
 
         // parallelize requests

--- a/src/analytics/AnalyticsBase.js
+++ b/src/analytics/AnalyticsBase.js
@@ -52,9 +52,7 @@ class AnalyticsBase {
 
         const dataReq = new AnalyticsRequest(req)
             .withSkipData(false)
-            .withSkipMeta(true)
-            .withIncludeNumDen(req.parameters.includeNumDen)
-            .withDisplayProperty('SHORTNAME');
+            .withSkipMeta(true);
 
         // parallelize requests
         return Promise.all([this.fetch(dataReq, { sorted: true }), this.fetch(metaDataReq)]).then(

--- a/src/analytics/__tests__/AnalyticsBase.spec.js
+++ b/src/analytics/__tests__/AnalyticsBase.spec.js
@@ -8,6 +8,7 @@ let base;
 describe('constructor', () => {
     beforeEach(() => {
         base = new AnalyticsBase(new MockApi());
+        base.api.get = jest.fn(() => Promise.resolve('OK'));
     });
 
     it('should not be allowed to be called without new', () => {
@@ -27,5 +28,27 @@ describe('constructor', () => {
         base = new AnalyticsBase(apiMockObject);
 
         expect(base.api).toBe(apiMockObject);
+    });
+
+    it('should respect includeNumDen property of the request object', () => {
+        const mockReq = {
+            parameters: {
+                includeNumDen: false,
+            },
+        };
+        base.get(mockReq);
+        expect(base.api.get.mock.calls[0][1]).toHaveProperty('includeNumDen', false);
+    });
+
+    it('should use the default value true for includeNumDen if no value was specified', () => {
+        const mockReq = {
+            parameters: {},
+        };
+        base.get(mockReq);
+        expect(base.api.get.mock.calls[0][1]).toHaveProperty('includeNumDen', true);
+    });
+
+    afterAll(() => {
+        base.api.get.resetMock();
     });
 });

--- a/src/analytics/__tests__/AnalyticsBase.spec.js
+++ b/src/analytics/__tests__/AnalyticsBase.spec.js
@@ -49,6 +49,6 @@ describe('constructor', () => {
     });
 
     afterAll(() => {
-        base.api.get.resetMock();
+        base.api.get.mockReset();
     });
 });

--- a/src/analytics/__tests__/AnalyticsBase.spec.js
+++ b/src/analytics/__tests__/AnalyticsBase.spec.js
@@ -8,7 +8,6 @@ let base;
 describe('constructor', () => {
     beforeEach(() => {
         base = new AnalyticsBase(new MockApi());
-        base.api.get = jest.fn(() => Promise.resolve('OK'));
     });
 
     it('should not be allowed to be called without new', () => {
@@ -28,27 +27,5 @@ describe('constructor', () => {
         base = new AnalyticsBase(apiMockObject);
 
         expect(base.api).toBe(apiMockObject);
-    });
-
-    it('should respect includeNumDen property of the request object', () => {
-        const mockReq = {
-            parameters: {
-                includeNumDen: false,
-            },
-        };
-        base.get(mockReq);
-        expect(base.api.get.mock.calls[0][1]).toHaveProperty('includeNumDen', false);
-    });
-
-    it('should use the default value true for includeNumDen if no value was specified', () => {
-        const mockReq = {
-            parameters: {},
-        };
-        base.get(mockReq);
-        expect(base.api.get.mock.calls[0][1]).toHaveProperty('includeNumDen', true);
-    });
-
-    afterAll(() => {
-        base.api.get.mockReset();
     });
 });


### PR DESCRIPTION
This PR will have the following result:
When you add `withIncludeNumDen(false)` to a request instance, and you then call `d2.analytics.aggregate.get(req)` the get request for the actual data will now also have `includeNumDen === false`.

Before this fix, it would default to true.

I've also included some tests.

Let me know if this should be merged or closed, and I'll take it from there.