### PR TITLE
fix(system-settings): update cache instead of deleting

### DIFF
--- a/src/system/SystemSettings.js
+++ b/src/system/SystemSettings.js
@@ -82,13 +82,27 @@ class SystemSettings {
     }
 
     set(systemSettingsKey, value) {
-        delete this.settings;
-
         const settingUrl = ['systemSettings', systemSettingsKey].join('/');
-        if (value === null || (`${value}`).length === 0) {
-            return this.api.delete(settingUrl);
+        if (value === null || `${value}`.length === 0) {
+            return this.api.delete(settingUrl).then((response) => {
+                // Update cache if present
+                if (this.settings && this.settings[systemSettingsKey]) {
+                    delete this.settings[systemSettingsKey];
+                }
+                return response;
+            });
         }
-        return this.api.post(settingUrl, value, { headers: { 'Content-Type': 'text/plain' } });
+        return this.api
+            .post(settingUrl, value, {
+                headers: { 'Content-Type': 'text/plain' },
+            })
+            .then((response) => {
+                // update cache if present
+                if (this.settings) {
+                    this.settings[systemSettingsKey] = value;
+                }
+                return response;
+            });
     }
 }
 

--- a/src/system/__tests__/SystemSettings.spec.js
+++ b/src/system/__tests__/SystemSettings.spec.js
@@ -209,12 +209,14 @@ describe('settings.System', () => {
                 });
         });
 
-        it('should clear the settings cache', () => systemSettings.all()
+        it('should update the settings cache', () => systemSettings.all()
             .then(() => systemSettings.set('test', 'value'))
             .then(() => systemSettings.all())
-            .then(() => {
-                expect(mockApi.get).toHaveBeenCalledTimes(2);
+            .then(() => systemSettings.get('test'))
+            .then((test) => {
+                expect(mockApi.get).toHaveBeenCalledTimes(1);
                 expect(mockApi.post).toHaveBeenCalledTimes(1);
+                expect(test).toEqual('value');
             }));
     });
 


### PR DESCRIPTION
### About this PR
There is not so much code to review, but quite a lot of context to explain:
- I found this issue in `d2` when working on [DHIS2-6860](https://jira.dhis2.org/browse/DHIS2-6860) in the settings-app.
- What happens is the following:
  1.   When the app is initialised a call to `d2.system.settings.all()` is done
  2.  Now we have access to `d2.system.settings.settings`. (Quite likely apps are not meant to access that property directly, but since `.get` returns a promise, I can imagine it is convenient to do so.)
  3.  Now, if any setting-field in the settings-app changes, a call to `d2.system.settings.set(key, value)` is done.
  4.  Before this PR, what would happen, is that the entire cached object is removed, which makes `typeof d2.system.settings.settings === 'undefined'`
  5. After this PR, the cached settings are updated instead of removed.

### Alternative approach
After studying the code in `SystemSettings` a bit more, I realised that you could argue that this problem was purely in the app, and that the behavior in `SystemSettings` was correct. This argument would be as follows:
- The app shouldn't have tried to access `d2.system.settings.settings` directly.
- Instead it should have used the proper API: calling `d2.system.settings.set(key)` returns a promise and will fetch a value from the server if the cached value is unavailable.

Looking forward to hearing what you think