### PR TITLE
fix(current-user): allow custom fields in getUserGroups (DHIS2-10625)

### DIFF
--- a/src/current-user/CurrentUser.js
+++ b/src/current-user/CurrentUser.js
@@ -157,15 +157,19 @@ class CurrentUser {
      *
      * The request done is equivalent do doing https://play.dhis2.org/demo/api/27/me.json?fields=userGroups[:all]
      *
+     * @param {Object} [listOptions={}] Additional query parameters that should be send with the request.
      * @returns {Promise<ModelCollection>} The model collection that contains the user's groups.
      */
-    getUserGroups() {
-        const userGroupIds = this[propertySymbols.userGroups]
+    getUserGroups(listOptions = {}) {
+        const userGroupIds = this[propertySymbols.userGroups];
 
-        return this[models].userGroup.list({
-            filter: [`id:in:[${userGroupIds.join(',')}]`],
-            paging: false,
-        })
+        return this[models].userGroup.list(
+            Object.assign(
+                { paging: false },
+                listOptions,
+                { filter: [`id:in:[${userGroupIds.join(',')}]`] },
+            ),
+        );
     }
 
     /**


### PR DESCRIPTION
This allows to override `fields=:all` to reduce the response size.
One example is the Interpretations component, where only the group ids
are actually needed.

See https://github.com/dhis2/d2-ui/pull/685.