### PR TITLE
fix: remove encoding of query string for analytics requests DHIS2-10722

### DIFF
--- a/src/analytics/AnalyticsRequestBase.js
+++ b/src/analytics/AnalyticsRequestBase.js
@@ -51,15 +51,13 @@ class AnalyticsRequestBase {
         if (options && options.sorted) {
             dimensions = sortBy(dimensions, 'dimension')
         }
-
-        const encodedDimensions = dimensions.map(({ dimension, items }) => {
+        const formattedDimensions = dimensions.map(({ dimension, items }) => {
             if (Array.isArray(items) && items.length) {
-                const encodedItems = items.map(customEncodeURIComponent)
                 if (options && options.sorted) {
-                    encodedItems.sort()
+                    items = sortBy(items)
                 }
 
-                return `${dimension}:${encodedItems.join(';')}`
+                return `${dimension}:${items.join(';')}`
             }
 
             return dimension
@@ -69,7 +67,7 @@ class AnalyticsRequestBase {
             .filter(e => !!e)
             .join('/')
 
-        return `${endPoint}.${this.format}?dimension=${encodedDimensions.join(
+        return `${endPoint}.${this.format}?dimension=${formattedDimensions.join(
             '&dimension='
         )}`
     }
@@ -94,21 +92,20 @@ class AnalyticsRequestBase {
             filters = sortBy(filters, 'dimension')
         }
 
-        const encodedFilters = filters.map(({ dimension, items }) => {
+        const formattedFilters = filters.map(({ dimension, items }) => {
             if (Array.isArray(items) && items.length) {
-                const encodedItems = items.map(customEncodeURIComponent)
                 if (options && options.sorted) {
-                    encodedItems.sort()
+                    items = sortBy(items)
                 }
 
-                return `${dimension}:${encodedItems.join(';')}`
+                return `${dimension}:${items.join(';')}`
             }
 
             return dimension
         })
 
         if (filters.length) {
-            this.parameters.filter = encodedFilters
+            this.parameters.filter = formattedFilters
         }
 
         return this.parameters

--- a/src/analytics/__tests__/AnalyticsRequestBase.spec.js
+++ b/src/analytics/__tests__/AnalyticsRequestBase.spec.js
@@ -1,9 +1,4 @@
 import AnalyticsRequestBase from '../AnalyticsRequestBase'
-import { customEncodeURIComponent } from '../../lib/utils'
-
-jest.mock('../../lib/utils', () => ({
-    customEncodeURIComponent: jest.fn(x => `<${x}>`),
-}))
 
 const endPoint = 'foo'
 const path = 'bar'
@@ -16,6 +11,7 @@ const dimensions = [
     { dimension: 'dx', items: ['population'] },
     { dimension: 'question' },
     { dimension: 'answer', items: ['42'] },
+    { dimension: 'space', items: ['in between'] },
 ]
 const buildRequest = overrides => {
     return new AnalyticsRequestBase({
@@ -31,55 +27,47 @@ const buildRequest = overrides => {
 }
 
 describe('AnalyticsRequestBase', () => {
-    beforeEach(() => {
-        customEncodeURIComponent.mockClear()
-    })
-
-    it('Should build a URL of encoded dimension parameters', () => {
+    it('Should build a URL of dimension parameters', () => {
         const request = buildRequest({ dimensions })
         const url = request.buildUrl()
-        expect(customEncodeURIComponent).toHaveBeenCalledTimes(4)
         expect(url).toBe(
-            `${basePath}?dimension=ou:<mars>;<earth>&dimension=dx:<population>&dimension=question&dimension=answer:<42>`
+            `${basePath}?dimension=ou:mars;earth&dimension=dx:population&dimension=question&dimension=answer:42&dimension=space:in between`
         )
     })
 
     it('Should build a URL with sorted dimension parameters when options.sorted=true', () => {
         const request = buildRequest({ dimensions })
         const url = request.buildUrl({ sorted: true })
-        expect(customEncodeURIComponent).toHaveBeenCalledTimes(4)
         expect(url).toBe(
-            `${basePath}?dimension=answer:<42>&dimension=dx:<population>&dimension=ou:<earth>;<mars>&dimension=question`
+            `${basePath}?dimension=answer:42&dimension=dx:population&dimension=ou:earth;mars&dimension=question&dimension=space:in between`
         )
     })
 
     it('Should not choke on a null or empty filter array', () => {
         const request = buildRequest()
         const query = request.buildQuery()
-        expect(customEncodeURIComponent).toHaveBeenCalledTimes(0)
         expect(query).toMatchObject({
             foo: 'bar',
         })
 
         const request2 = buildRequest({ filters: [] })
         const query2 = request2.buildQuery()
-        expect(customEncodeURIComponent).toHaveBeenCalledTimes(0)
         expect(query2).toMatchObject({
             foo: 'bar',
         })
     })
 
-    it('Should build a query with encoded filter parameters', () => {
+    it('Should build a query with filter parameters', () => {
         const request = buildRequest({ filters: dimensions })
         const query = request.buildQuery()
-        expect(customEncodeURIComponent).toHaveBeenCalledTimes(4)
         expect(query).toMatchObject({
             foo: 'bar',
             filter: [
-                'ou:<mars>;<earth>',
-                'dx:<population>',
+                'ou:mars;earth',
+                'dx:population',
                 'question',
-                'answer:<42>',
+                'answer:42',
+                'space:in between',
             ],
         })
     })
@@ -87,14 +75,14 @@ describe('AnalyticsRequestBase', () => {
     it('Should build a query with sorted filter parameters when options.sorted=true', () => {
         const request = buildRequest({ filters: dimensions })
         const query = request.buildQuery({ sorted: true })
-        expect(customEncodeURIComponent).toHaveBeenCalledTimes(4)
         expect(query).toMatchObject({
             foo: 'bar',
             filter: [
-                'answer:<42>',
-                'dx:<population>',
-                'ou:<earth>;<mars>',
+                'answer:42',
+                'dx:population',
+                'ou:earth;mars',
                 'question',
+                'space:in between',
             ],
         })
     })


### PR DESCRIPTION
Fixes [DHIS2-10722](https://jira.dhis2.org/browse/DHIS2-10722)

Due to the encoding being done in d2 request, having it here causes a
double encoding problem, which throws an error and stops the request
from being fired.

After the fix:

https://user-images.githubusercontent.com/150978/111803241-28db4a80-88cf-11eb-9a58-1d513aac8bf3.mov

