### PR TITLE
feat(json): treat access collection as non-model collections

### DIFF
--- a/src/model/helpers/json.js
+++ b/src/model/helpers/json.js
@@ -25,6 +25,8 @@ const NON_MODEL_COLLECTIONS = {
     filters: [],
     yearlySeries: [],
     interpretations: ['chart'],
+    userGroupAccesses: [],
+    userAccesses: [],
 }
 
 const isNonModelCollection = (propertyName, modelType) => {


### PR DESCRIPTION
This fixes so that userGroupAccesses and userAccesses send `access` and other nested fields when saved. This is used in maintenance app mainly. 

Related to these fixes https://github.com/dhis2/maintenance-app/pull/1812 and https://github.com/dhis2/maintenance-app/pull/1817