### PR TITLE
feat(json): treat access collection as non-model collections

### DIFF
--- a/src/model/helpers/json.js
+++ b/src/model/helpers/json.js
@@ -17,6 +17,8 @@ const NON_MODEL_COLLECTIONS = {
     redirectUris: ['oAuth2Client'],
     organisationUnitLevels: ['validationRule'],
     favorites: [],
+    userGroupAccesses: [],
+    userAccesses: [],
 };
 
 const isNonModelCollection = (propertyName, modelType) => {


### PR DESCRIPTION
Backport to v30 of #292 . Maintenance app can't use v31+ yet due to import changes (from `d2/lib` to flattened imports `d2`