### PR TITLE
fix(api): allow Content-Type override for update()

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -206,7 +206,8 @@ class Api {
      * @param {string} url The url for the request
      * @param {*} data Any data that should be send with the request. This becomes the body of the PUT request.
      * @param {boolean} [useMergeStrategy=false]
-     *
+     * @param {Object.<string, any>} options The request options are passed as options to the fetch request.
+     * 
      * @returns {Promise.<*>} The response body.
      */
     update(url, data, useMergeStrategy = false, options = {}) {

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -211,15 +211,18 @@ class Api {
      */
     update(url, data, useMergeStrategy = false, options = {}) {
         let payload = data
+
         // Ensure that headers are defined and are treated without case sensitivity
-        options.headers = new Headers(options.headers || {})
+        const requestOptions = {
+            headers: new Headers(options.headers || {})
+        }
 
         if (data !== undefined) {
             if (
-                !options.headers.has('Content-Type') &&
+                !requestOptions.headers.has('Content-Type') &&
                 typeof payload === 'string'
             ) {
-                options.headers.set('Content-Type', 'text/plain')
+                requestOptions.headers.set('Content-Type', 'text/plain')
             } else {
                 payload = JSON.stringify(data)
             }
@@ -234,7 +237,7 @@ class Api {
             'PUT',
             getUrl(this.baseUrl, urlForUpdate),
             payload,
-            options
+            requestOptions
         )
     }
 

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -207,7 +207,7 @@ class Api {
      * @param {*} data Any data that should be send with the request. This becomes the body of the PUT request.
      * @param {boolean} [useMergeStrategy=false]
      * @param {Object.<string, any>} options The request options are passed as options to the fetch request.
-     * 
+     *
      * @returns {Promise.<*>} The response body.
      */
     update(url, data, useMergeStrategy = false, options = {}) {
@@ -216,7 +216,7 @@ class Api {
         // Ensure that headers are defined and are treated without case sensitivity
         const requestOptions = {
             ...options,
-            headers: new Headers(options.headers || {})
+            headers: new Headers(options.headers || {}),
         }
 
         if (data !== undefined) {

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -209,26 +209,32 @@ class Api {
      *
      * @returns {Promise.<*>} The response body.
      */
-    update(url, data, useMergeStrategy = false) {
-        // Since we are currently using PUT to save the full state back, we have to use mergeMode=REPLACE
-        // to clear out existing values
+    update(url, data, useMergeStrategy = false, options = {}) {
+        let payload = data
+        // Ensure that headers are defined and are treated without case sensitivity
+        options.headers = new Headers(options.headers || {})
+
+        if (data !== undefined) {
+            if (
+                !options.headers.has('Content-Type') &&
+                typeof payload === 'string'
+            ) {
+                options.headers.set('Content-Type', 'text/plain')
+            } else {
+                payload = JSON.stringify(data)
+            }
+        }
+
         const urlForUpdate =
             useMergeStrategy === true
                 ? `${url}?${getMergeStrategyParam()}`
                 : url
-        if (typeof data === 'string') {
-            return this.request(
-                'PUT',
-                getUrl(this.baseUrl, urlForUpdate),
-                String(data),
-                { headers: new Headers({ 'Content-Type': 'text/plain' }) }
-            )
-        }
 
         return this.request(
             'PUT',
             getUrl(this.baseUrl, urlForUpdate),
-            JSON.stringify(data)
+            payload,
+            options
         )
     }
 

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -215,6 +215,7 @@ class Api {
 
         // Ensure that headers are defined and are treated without case sensitivity
         const requestOptions = {
+            ...options,
             headers: new Headers(options.headers || {})
         }
 

--- a/src/datastore/BaseStoreNamespace.js
+++ b/src/datastore/BaseStoreNamespace.js
@@ -138,7 +138,11 @@ class BaseStoreNamespace {
     update(key, value) {
         return this.api.update(
             [this.endPoint, this.namespace, key].join('/'),
-            value
+            value,
+            false,
+            {
+                headers: { 'Content-Type': 'application/json' },
+            }
         )
     }
 }

--- a/src/datastore/__tests__/DatastoreNamespace.spec.js
+++ b/src/datastore/__tests__/DatastoreNamespace.spec.js
@@ -168,7 +168,11 @@ describe('DataStoreNamespace', () => {
                 expect(namespace.update).toBeCalledWith(setKey, valueData)
                 expect(apiMock.update).toBeCalledWith(
                     `dataStore/DHIS/${setKey}`,
-                    valueData
+                    valueData,
+                    false,
+                    {
+                        headers: { 'Content-Type': 'application/json' }
+                    }
                 )
             })
         })
@@ -268,7 +272,11 @@ describe('DataStoreNamespace', () => {
             return namespace.update(setKey, valueData).then(() => {
                 expect(apiMock.update).toBeCalledWith(
                     `dataStore/DHIS/${setKey}`,
-                    valueData
+                    valueData,
+                    false,
+                    {
+                        headers: { 'Content-Type': 'application/json' }
+                    }
                 )
             })
         })

--- a/src/datastore/__tests__/DatastoreNamespace.spec.js
+++ b/src/datastore/__tests__/DatastoreNamespace.spec.js
@@ -171,7 +171,7 @@ describe('DataStoreNamespace', () => {
                     valueData,
                     false,
                     {
-                        headers: { 'Content-Type': 'application/json' }
+                        headers: { 'Content-Type': 'application/json' },
                     }
                 )
             })
@@ -275,7 +275,7 @@ describe('DataStoreNamespace', () => {
                     valueData,
                     false,
                     {
-                        headers: { 'Content-Type': 'application/json' }
+                        headers: { 'Content-Type': 'application/json' },
                     }
                 )
             })

--- a/src/datastore/__tests__/UserDatastoreNamespace.spec.js
+++ b/src/datastore/__tests__/UserDatastoreNamespace.spec.js
@@ -168,7 +168,11 @@ describe('DataStoreNamespace', () => {
                 expect(namespace.update).toBeCalledWith(setKey, valueData)
                 expect(apiMock.update).toBeCalledWith(
                     `dataStore/DHIS/${setKey}`,
-                    valueData
+                    valueData,
+                    false,
+                    {
+                        headers: { 'Content-Type': 'application/json' }
+                    }
                 )
             })
         })
@@ -268,7 +272,11 @@ describe('DataStoreNamespace', () => {
             return namespace.update(setKey, valueData).then(() => {
                 expect(apiMock.update).toBeCalledWith(
                     `dataStore/DHIS/${setKey}`,
-                    valueData
+                    valueData,
+                    false,
+                    {
+                        headers: { 'Content-Type': 'application/json' }
+                    }
                 )
             })
         })

--- a/src/datastore/__tests__/UserDatastoreNamespace.spec.js
+++ b/src/datastore/__tests__/UserDatastoreNamespace.spec.js
@@ -171,7 +171,7 @@ describe('DataStoreNamespace', () => {
                     valueData,
                     false,
                     {
-                        headers: { 'Content-Type': 'application/json' }
+                        headers: { 'Content-Type': 'application/json' },
                     }
                 )
             })
@@ -275,7 +275,7 @@ describe('DataStoreNamespace', () => {
                     valueData,
                     false,
                     {
-                        headers: { 'Content-Type': 'application/json' }
+                        headers: { 'Content-Type': 'application/json' },
                     }
                 )
             })


### PR DESCRIPTION
Fix for [https://jira.dhis2.org/browse/DHIS2-12135](https://jira.dhis2.org/browse/DHIS2-12135)

Previously, `api.update()` inferred the content-type from the type of the `value`, so when it was a string, content-type was set to `text/plain`. However, there was no way to override this, like for the `api.post`-method. It's a bit weird to me that these methods do not follow the same api/use shared logic. Nevertheless, I did not want to introduce a breaking change here due to this repo being in "maintenance"-mode. So that is why I included the previous functionality of setting to `text/plain` if headers are not set, and the type of the value is a `string`.

Updates the `update()` in `DataStoreNameSpace` to override the headers so that it always PUTs `json`.