### PR TITLE
fix: fix crash when server-url contains api

### DIFF
--- a/src/lib/__tests__/utils.spec.js
+++ b/src/lib/__tests__/utils.spec.js
@@ -78,10 +78,10 @@ describe('Utils', () => {
         });
 
         it('works when domain contains api and version', () => {
-            const url = 'https://dhis2-api.org/api/25';
+            const url = 'https://dhis2-api.org/api/25/api/29';
                 expect(
                     utils.updateAPIUrlWithBaseUrlVersionNumber(
-                        'https://dhis2-api.org/api/25/api/29/dataSetElements/abcDEFghi3',
+                        'https://dhis2-api.org/api/25/api/dataSetElements/abcDEFghi3',
                         `${url}`,
                     )
                 ).toBe(
@@ -96,21 +96,6 @@ describe('Utils', () => {
                 ),
             ).toBe(
                 'https://localhost:8080/dhis/api/25/dataSetElements/abcDEFghi3');
-
-            expect(
-                utils.updateAPIUrlWithBaseUrlVersionNumber(
-                    'https://localhost:8080/dhis/api/api/25/dataSetElements/abcDEFghi3',
-                    `${baseUrl}/26`,
-                ),
-            ).toBe(
-                'https://localhost:8080/dhis/api/api/25/dataSetElements/abcDEFghi3');
-            expect(
-                utils.updateAPIUrlWithBaseUrlVersionNumber(
-                    'https://localhost:8080/dhis/api/99/api/25/dataSetElements/abcDEFghi3',
-                    `${baseUrl}/26`,
-                ),
-            ).toBe(
-                'https://localhost:8080/dhis/api/99/api/25/dataSetElements/abcDEFghi3');
         });
 
         it('works when server context contains api', () => {
@@ -121,6 +106,26 @@ describe('Utils', () => {
                 ),
             ).toBe('https://dhis2.org/api/api/26/dataSetElements/abcDEFghi3');
         });
+
+        it('does not replace version when APIUrl contains version and server context contains api', () => {
+            expect(
+                utils.updateAPIUrlWithBaseUrlVersionNumber(
+                    'https://localhost:8080/dhis/api/api/25/dataSetElements/abcDEFghi3',
+                    `${baseUrl}/26`,
+                ),
+            ).toBe(
+                'https://localhost:8080/dhis/api/api/25/dataSetElements/abcDEFghi3');
+        })
+
+        it('does not replace version when APIUrl contains version and server context contains api and version', () => {
+            expect(
+                utils.updateAPIUrlWithBaseUrlVersionNumber(
+                    'https://localhost:8080/dhis/api/99/api/25/dataSetElements/abcDEFghi3',
+                    `${baseUrl}/26`,
+                ),
+            ).toBe(
+                'https://localhost:8080/dhis/api/99/api/25/dataSetElements/abcDEFghi3');
+        })
     });
 
     describe('pickOr', () => {

--- a/src/lib/__tests__/utils.spec.js
+++ b/src/lib/__tests__/utils.spec.js
@@ -67,41 +67,61 @@ describe('Utils', () => {
         });
 
         it('works when domain contains api', () => {
-            const baseUrl = 'https://dhis2-api.org/api'
-            for (let i = 10; i < 99; i++) {
+            const url = 'https://dhis2-api.org/api/29';
                 expect(
                     utils.updateAPIUrlWithBaseUrlVersionNumber(
                         'https://dhis2-api.org/api/api/dataSetElements/abcDEFghi3',
-                        `${baseUrl}/${i}`
+                        `${url}`,
+                    ),
+                ).toBe(
+                    `https://dhis2-api.org/api/api/29/dataSetElements/abcDEFghi3`);
+        });
+
+        it('works when domain contains api and version', () => {
+            const url = 'https://dhis2-api.org/api/25';
+                expect(
+                    utils.updateAPIUrlWithBaseUrlVersionNumber(
+                        'https://dhis2-api.org/api/25/api/29/dataSetElements/abcDEFghi3',
+                        `${url}`,
                     )
                 ).toBe(
-                    `https://dhis2-api.org/api/api/${i}/dataSetElements/abcDEFghi3`
-                );
-            }
-        });
+                    `https://dhis2-api.org/api/25/api/29/dataSetElements/abcDEFghi3`);
+        })
 
         it('does not replace version when apiUrl contains version', () => {
             expect(
                 utils.updateAPIUrlWithBaseUrlVersionNumber(
                     'https://localhost:8080/dhis/api/25/dataSetElements/abcDEFghi3',
-                    `${baseUrl}/26`
-                )
+                    `${baseUrl}/26`,
+                ),
             ).toBe(
-                'https://localhost:8080/dhis/api/25/dataSetElements/abcDEFghi3'
-            );
+                'https://localhost:8080/dhis/api/25/dataSetElements/abcDEFghi3');
+
+            expect(
+                utils.updateAPIUrlWithBaseUrlVersionNumber(
+                    'https://localhost:8080/dhis/api/api/25/dataSetElements/abcDEFghi3',
+                    `${baseUrl}/26`,
+                ),
+            ).toBe(
+                'https://localhost:8080/dhis/api/api/25/dataSetElements/abcDEFghi3');
+            expect(
+                utils.updateAPIUrlWithBaseUrlVersionNumber(
+                    'https://localhost:8080/dhis/api/99/api/25/dataSetElements/abcDEFghi3',
+                    `${baseUrl}/26`,
+                ),
+            ).toBe(
+                'https://localhost:8080/dhis/api/99/api/25/dataSetElements/abcDEFghi3');
         });
 
         it('works when server context contains api', () => {
             expect(
                 utils.updateAPIUrlWithBaseUrlVersionNumber(
                     'https://dhis2.org/api/api/dataSetElements/abcDEFghi3',
-                    'https://dhis2.org/api/api/26'
-                )
-            ).toBe(
-                'https://dhis2.org/api/api/26/dataSetElements/abcDEFghi3'
-            );
+                    'https://dhis2.org/api/api/26',
+                ),
+            ).toBe('https://dhis2.org/api/api/26/dataSetElements/abcDEFghi3');
         });
-    })
+    });
 
     describe('pickOr', () => {
         it('should return the defaultValue if it was defined', () => {

--- a/src/lib/__tests__/utils.spec.js
+++ b/src/lib/__tests__/utils.spec.js
@@ -65,7 +65,43 @@ describe('Utils', () => {
                 )).toBe(`https://localhost:8080/dhis/api/${i}/dataSetElements/abcDEFghi3`);
             }
         });
-    });
+
+        it('works when domain contains api', () => {
+            const baseUrl = 'https://dhis2-api.org/api'
+            for (let i = 10; i < 99; i++) {
+                expect(
+                    utils.updateAPIUrlWithBaseUrlVersionNumber(
+                        'https://dhis2-api.org/api/api/dataSetElements/abcDEFghi3',
+                        `${baseUrl}/${i}`
+                    )
+                ).toBe(
+                    `https://dhis2-api.org/api/api/${i}/dataSetElements/abcDEFghi3`
+                );
+            }
+        });
+
+        it('does not replace version when apiUrl contains version', () => {
+            expect(
+                utils.updateAPIUrlWithBaseUrlVersionNumber(
+                    'https://localhost:8080/dhis/api/25/dataSetElements/abcDEFghi3',
+                    `${baseUrl}/26`
+                )
+            ).toBe(
+                'https://localhost:8080/dhis/api/25/dataSetElements/abcDEFghi3'
+            );
+        });
+
+        it('works when server context contains api', () => {
+            expect(
+                utils.updateAPIUrlWithBaseUrlVersionNumber(
+                    'https://dhis2.org/api/api/dataSetElements/abcDEFghi3',
+                    'https://dhis2.org/api/api/26'
+                )
+            ).toBe(
+                'https://dhis2.org/api/api/26/dataSetElements/abcDEFghi3'
+            );
+        });
+    })
 
     describe('pickOr', () => {
         it('should return the defaultValue if it was defined', () => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -80,6 +80,8 @@ export function updateAPIUrlWithBaseUrlVersionNumber(apiUrl, baseUrl) {
         return apiUrl;
     }
 
+    // match the last version number
+    // negative lookahead to ensure that match is the last occurence
     const apiUrlWithVersionRexExp = /api\/([1-9][0-9])(?!.*api\/)/;
     const baseUrlVersionMatch = baseUrl.match(apiUrlWithVersionRexExp);
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -81,19 +81,23 @@ export function updateAPIUrlWithBaseUrlVersionNumber(apiUrl, baseUrl) {
     }
 
     const apiUrlWithVersionRexExp = /api\/([1-9][0-9])/;
-    const apiVersionMatch = baseUrl.match(apiUrlWithVersionRexExp);
+    const baseUrlVersionMatch = baseUrl.match(apiUrlWithVersionRexExp);
+    const apiUrlHasVersion = apiUrl && apiUrlWithVersionRexExp.test(apiUrl);
 
-    const baseUrlHasVersion = apiVersionMatch && apiVersionMatch[1];
-    const apiUrlHasVersion = apiUrl && !apiUrlWithVersionRexExp.test(apiUrl);
-
-    if (baseUrlHasVersion && apiUrlHasVersion) {
-        const version = apiVersionMatch[1];
-
-        // Inject the current api version number into the endPoint urls
-        return apiUrl.replace(/api/, `api/${version}`);
+    // use apiUrl directly if it contains version or no match for baseUrl
+    if (apiUrlHasVersion || !baseUrlVersionMatch) {
+        return apiUrl;
     }
 
-    return apiUrl;
+    const lastApiPartIndex = apiUrl.lastIndexOf("/api/");
+    
+    if(lastApiPartIndex === -1) {
+        return apiUrl;
+    }
+
+    return `${apiUrl.substring(0, lastApiPartIndex)}/${
+        baseUrlVersionMatch[0]
+    }/${apiUrl.substring(lastApiPartIndex + 5)}`;
 }
 
 // Define our very own special list of characters that we don't want to encode in the URI

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -80,8 +80,9 @@ export function updateAPIUrlWithBaseUrlVersionNumber(apiUrl, baseUrl) {
         return apiUrl;
     }
 
-    const apiUrlWithVersionRexExp = /api\/([1-9][0-9])/;
+    const apiUrlWithVersionRexExp = /api\/([1-9][0-9])(?!.*api\/)/;
     const baseUrlVersionMatch = baseUrl.match(apiUrlWithVersionRexExp);
+
     const apiUrlHasVersion = apiUrl && apiUrlWithVersionRexExp.test(apiUrl);
 
     // use apiUrl directly if it contains version or no match for baseUrl
@@ -89,9 +90,9 @@ export function updateAPIUrlWithBaseUrlVersionNumber(apiUrl, baseUrl) {
         return apiUrl;
     }
 
-    const lastApiPartIndex = apiUrl.lastIndexOf("/api/");
-    
-    if(lastApiPartIndex === -1) {
+    const lastApiPartIndex = apiUrl.lastIndexOf('/api/');
+
+    if (lastApiPartIndex === -1) {
         return apiUrl;
     }
 


### PR DESCRIPTION
Part of fix for https://dhis2.atlassian.net/browse/DHIS2-16237
Maintenance app needs to update to new D2 version once this is merged and released for v30. 

Previously the maintenance app would crash when hosted on a server domain that contains "api", eg. `dhis2-api.org`. Because this logic simply replaced the first occurrence. The correct way would be to replace the last occurrence, because we don't want to interfere with the user-definable portion of the url (eg. domain and server context). 

Opted to do the matching programatically instead of replace with regex, because a regex for last occurrence gets pretty complicated and messy. 